### PR TITLE
updated circle image to use Debain 9 stretch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,10 @@ version: 2.1
 executors:
   python-3-6:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.6-stretch
   python-3-7:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.7-stretch
   vm:
     machine:
       enabled: true


### PR DESCRIPTION
The latest python 3.7 image that CircleCI provides breaks pyinstaller reckoner binaries.

```[1808] Error loading Python lib '/tmp/_MEIT640ZK/libpython3.7m.so.1.0': dlopen: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /tmp/_MEIT640ZK/libpython3.7m.so.1.0)```

This is due to the official python images switching to Debian 10 (buster). This PR pins the CircleCI executors to run on a Debian 9 (stretch) image.