### PR TITLE
Fix Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For development see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 In course.yaml, write:
 ```yaml
-namespace: kube-system
+namespace: default
 charts:
   grafana:
     namespace: grafana

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For development see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 In course.yaml, write:
 ```yaml
+namespace: kube-system
 charts:
   grafana:
     namespace: grafana


### PR DESCRIPTION
It looks like we started requiring `namespace` in the top-level. Was this intentional? Seems unnecessary if each chart defines its own namespace.