### PR TITLE
Fix values file pathing

### DIFF
--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -377,9 +377,11 @@ class Chart(object):
         """
         This method builds the files list for all
         files specified in the course.yml
+        Note: values_file must be relative to the course.yml, or declared with an absolute path
         """
         for values_file in self.files:
-            self._append_arg("-f {}".format(self.config.course_base_directory + "/" + values_file))
+            values_file_path = os.path.join(self.config.course_base_directory, values_file)
+            self._append_arg("-f {}".format(values_file_path))
 
     @staticmethod
     def _interpolate_env_vars_from_string(original_string: str) -> str:

--- a/reckoner/config.py
+++ b/reckoner/config.py
@@ -17,7 +17,7 @@
 
 import os
 import logging
-from os.path import dirname
+from os.path import dirname, abspath
 
 from .command_line_caller import call
 
@@ -71,7 +71,7 @@ class Config(object):
 
     @property
     def course_base_directory(self):
-        return dirname(self.course_path) or None
+        return dirname(abspath(self.course_path))
 
     def __setattr__(self, name, value):
         object.__setattr__(self, name, value)

--- a/reckoner/tests/test_config.py
+++ b/reckoner/tests/test_config.py
@@ -13,24 +13,27 @@
 # limitations under the License.
 
 import unittest
+import mock
 from reckoner.config import Config
 
 
 class TestConfig(unittest.TestCase):
-    def test_course_base_dir_never_empty(self):
+    @mock.patch('os.getcwd')
+    def test_course_base_dir_never_empty(self, mock_dir):
         config = Config()
         config.course_path = 'course.yaml'
         self.assertNotEqual('', config.course_base_directory,
                             "course_base_path has to be None or a real path "
                             "(including '.') because of how it is used in "
                             "Popen. Cannot be an empty string.")
-        self.assertIsNone(config.course_base_directory)
 
         config.course_path = '/some/full/path/course.yml'
         self.assertEqual('/some/full/path', config.course_base_directory)
 
+        mock_dir.return_value = "/some/fake/path"
         config.course_path = './course.yaml'
-        self.assertEqual('.', config.course_base_directory)
+        self.assertEqual('/some/fake/path', config.course_base_directory)
 
+        # relative path to /some/fake/path
         config.course_path = '../../relative/course.yml'
-        self.assertEqual('../../relative', config.course_base_directory)
+        self.assertEqual('/some/relative', config.course_base_directory)


### PR DESCRIPTION
Relevant issue: https://github.com/FairwindsOps/reckoner/issues/145

This PR makes `course_base_directory` an absolute path. Added `os.path.join` to `chart.build_files_list()` 