### PR TITLE
Fixes for repository/repositories settings with git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed issues where helm would try to interpolate variables in comments provided in `values: {}` section of a chart definition
 - Added better logging for debug when unexpected errors happen in python
 - Added better logging output for debugging yaml parse issues
+- Fixed repository git support for defining git chart endpoints at the top level and chart level
 
 ## [2.1.1]
 ### Fixes

--- a/end_to_end_testing/run_end_to_end.sh
+++ b/end_to_end_testing/run_end_to_end.sh
@@ -239,7 +239,7 @@ function e2e_test_git_chart() {
 
     # Special Clean up of GoHarbor
     helm delete --purge go-harbor
-    kubectl delete pvc -n test --all
+    kubectl delete pvc --all-namespaces --all
 }
 
 function e2e_test_stop_after_first_failure() {

--- a/end_to_end_testing/test_git_chart.yml
+++ b/end_to_end_testing/test_git_chart.yml
@@ -8,6 +8,11 @@ repositories:
     url: https://charts.fairwinds.com/stable
   fairwinds-incubator:
     url: https://charts.fairwinds.com/incubator
+  polaris-repo-test:
+    git: https://github.com/FairwindsOps/charts
+    path: stable
+  the-go-harbor-repo:
+    git: https://github.com/goharbor/harbor-helm.git
 minimum_versions: #set minimum version requirements here
   helm: 0.0.0
   reckoner: 0.0.0
@@ -15,14 +20,22 @@ charts:
   polaris-release:
     namespace: polaris
     chart: polaris
-    repository:
-      git: https://github.com/FairwindsOps/charts
-      path: stable
+    repository: polaris-repo-test
   polaris:
     namespace: another-polaris
     repository:
       git: https://github.com/FairwindsOps/charts.git
       path: stable
   go-harbor:
+    chart: go-harbor
     repository:
       git: https://github.com/goharbor/harbor-helm.git
+    values:
+      persistence:
+        enabled: false
+  go-harbor-two:
+    namespace: a-different-one
+    repository: the-go-harbor-repo
+    values:
+      persistence:
+        enabled: false

--- a/reckoner/course.py
+++ b/reckoner/course.py
@@ -74,9 +74,8 @@ class Course(object):
             self._charts.append(Chart({name: chart}, self.helm))
 
         for repo in self._repositories:
-            type(repo)
             logging.debug("Installing repository: {}".format(repo))
-            repo.install()
+            repo.install(chart_name=repo._repository['name'], version=repo._repository.get('version'))
 
         self.helm.repo_update()
 

--- a/reckoner/repository.py
+++ b/reckoner/repository.py
@@ -67,7 +67,7 @@ class Repository(object):
     def chart_path(self):
         return self._chart_path
 
-    def install(self, chart_name=None, version=None):
+    def install(self, chart_name, version=None):
         """ Install Helm repository """
         # TODO: This function needs some love - seems like it wants to return T/F and maybe have logic act on that vs raising errors when you cannot install (from this function)
         if self.git is None:

--- a/reckoner/repository.py
+++ b/reckoner/repository.py
@@ -38,7 +38,7 @@ class Repository(object):
     """
 
     def __init__(self, repository, helm_client: HelmClient):
-        super(type(self), self).__init__()
+        super(type(self), self).__init__()  # TODO: Remove this and test thoroughly, it appears this doesn't do anything.
         self.config = Config()
         self._repository = {}
         self._helm_client = helm_client


### PR DESCRIPTION
Fixes #152 

## Background
Quick synopsis of #152 is that the `repositories` settings in the course schema behaves differently than setting the same settings in each chart `repository` key/value. In order to try to normalize the behavior, but still keep some existing behavior, I've added a "reconciliation" step to the course parsing. Now when a chart has a string set, it will try to resolve the string to the key set in the `repositories: {}` section at the root of the document. If that repository key name does not exist, it will just leave it alone and keep the string in place (current behavior). If the key _does_ exist, then the course will replace the string with the repository configuration.

## Changes
- Added fix to provide a chart name and version when installing repos at the whole course level
- Added a reconcile method to convert reference strings to the actual repository config for each chart
- Added tests