### PR TITLE
Ejether/update exception for helm 3 client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ jobs:
       - store_artifacts:
           path: installer/dist/reckoner
           destination: reckoner-darwin
-  end-to-end:
+  end-to-end-helmv2:
     executor: vm
     working_directory: ~/reckoner
     resource_class: medium
@@ -152,10 +152,24 @@ jobs:
           at: /tmp/binaries
       - run:
           name: Setup Testing Environment
-          command: "./end_to_end_testing/setup.sh"
+          command: "./end_to_end_testing/setup_helm2.sh"
       - run:
           name: Run end to end tests
-          command: "./end_to_end_testing/run_end_to_end.sh"
+          command: HELM_VERSION=2 "./end_to_end_testing/run_end_to_end.sh"
+  end-to-end-helmv3:
+    executor: vm
+    working_directory: ~/reckoner
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/binaries
+      - run:
+          name: Setup Testing Environment
+          command: "./end_to_end_testing/setup_helm3.sh"
+      - run:
+          name: Run end to end tests
+          command: HELM_VERSION=3 "./end_to_end_testing/run_end_to_end.sh"
   publish-binaries:
     executor: python-3-7
     steps:
@@ -215,7 +229,16 @@ workflows:
               only: /.*/
             branches:
               only: /.*/
-      - end-to-end:
+      - end-to-end-helmv2:
+          requires:
+            - compile
+            - compile-darwin
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: /.*/
+      - end-to-end-helmv3:
           requires:
             - compile
             - compile-darwin
@@ -226,7 +249,7 @@ workflows:
               only: /.*/
       - release:
           requires:
-            - end-to-end
+            - end-to-end-helmv2
           filters:
             tags:
               only: /.*/
@@ -234,7 +257,7 @@ workflows:
               ignore: /.*/
       - publish-binaries:
           requires:
-            - end-to-end
+            - end-to-end-helmv2
           filters:
             tags:
               only: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- bug where the helm client version check would fail for helm2 and never proceed to check helm3
+
 ## [2.2.0]
 ### Changes
 - Added a warning message when using helm3: NOTE HELM3 IS NOT YET SUPPORTED! Use at your own peril!

--- a/HELM3_BLOCKERS.md
+++ b/HELM3_BLOCKERS.md
@@ -8,9 +8,6 @@
   - While this isn’t necessarily  a blocker, Helm 3 performs a three way merge operation when patching. Check this [PR](https://github.com/helm/helm/pull/6124) for more details
   - Some charts may be non-upgradeable depending on how they handle immutable fields
     - For example, the nginx-ingress chart fails to `upgrade` after being installed if some values are unset. See this [issue](https://github.com/helm/helm/issues/6378) for the details and workaround.
-- No `--output json`
-  - Check this [issue](https://github.com/helm/helm/issues/6437) for more details
-  - This breaks the endtoend testing suite.
 - Helm 3 does not create namespaces.
   - Workaround is to create the namespace in a `pre_install` hook.
   - Non-existent namespaces issue <https://github.com/FairwindsOps/reckoner/issues/75>

--- a/end_to_end_testing/setup_common.sh
+++ b/end_to_end_testing/setup_common.sh
@@ -24,12 +24,6 @@ chmod 0755 kubectl
 sudo mv kubectl /usr/local/bin/
 kubectl version --client
 
-echo "Installing Helm"
-curl -sL https://storage.googleapis.com/kubernetes-helm/helm-v2.14.2-linux-amd64.tar.gz | tar xzv linux-amd64/helm
-sudo mv linux-amd64/helm /usr/local/bin/helm
-rm -rf linux-amd64
-helm version --client
-
 echo "Creating Kubernetes Cluster with Kind"
 kind create cluster --wait=90s --image kindest/node:v1.14.3
 docker ps -a
@@ -37,8 +31,3 @@ docker ps -a
 echo "Setting up kubecfg"
 cp "$(kind get kubeconfig-path --name=kind)" ~/.kube/config
 kubectl version
-
-echo "Setting up Helm on Kubernetes"
-kubectl -n kube-system create serviceaccount tiller
-kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount kube-system:tiller
-helm init --service-account tiller --wait

--- a/end_to_end_testing/setup_helm2.sh
+++ b/end_to_end_testing/setup_helm2.sh
@@ -1,0 +1,12 @@
+source "$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/setup_common.sh
+
+echo "Installing Helm"
+curl -sL https://storage.googleapis.com/kubernetes-helm/helm-v2.14.2-linux-amd64.tar.gz | tar xzv linux-amd64/helm
+sudo mv linux-amd64/helm /usr/local/bin/helm
+rm -rf linux-amd64
+helm version --client
+
+echo "Setting up Helm on Kubernetes"
+kubectl -n kube-system create serviceaccount tiller
+kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount kube-system:tiller
+helm init --service-account tiller --wait

--- a/end_to_end_testing/setup_helm3.sh
+++ b/end_to_end_testing/setup_helm3.sh
@@ -1,0 +1,17 @@
+source "$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/setup_common.sh
+
+echo "Installing Helm"
+curl -sL https://get.helm.sh/helm-v3.0.1-linux-amd64.tar.gz | tar xzv linux-amd64/helm
+sudo mv linux-amd64/helm /usr/local/bin/helm
+rm -rf linux-amd64
+helm version
+
+kubectl create namespace infra
+kubectl create namespace test
+kubectl create namespace testing
+kubectl create namespace polaris
+kubectl create namespace another-polaris
+kubectl create namespace a-different-one
+kubectl create namespace redis-test-namespace
+
+helm repo add stable https://kubernetes-charts.storage.googleapis.com

--- a/end_to_end_testing/test_strong_typing.yml
+++ b/end_to_end_testing/test_strong_typing.yml
@@ -3,6 +3,9 @@ namespace: testing #namespace to install the chart in, defaults to 'kube-system'
 minimum_versions: #set minimum version requirements here
   helm: 0.0.0
   reckoner: 0.0.0
+repositories:
+  stable:
+    url: https://kubernetes-charts.storage.googleapis.com
 charts:
   chart-values:
     repository: stable

--- a/reckoner/helm/client.py
+++ b/reckoner/helm/client.py
@@ -52,8 +52,9 @@ def get_helm_client(helm_arguments, client_version=None, helm_provider=HelmProvi
                 logging.info('Found Helm Version {}'.format(detected_version))
                 logging.info('Tiller version {}'.format(client2.tiller_version))
                 return client2
-            except HelmVersionException:
+            except (HelmClientException, HelmVersionException) as e:
                 logging.debug('Helm 2 check failed')
+                logging.debug(e)
                 logging.debug('Checking for Helm 3 client')
                 detected_version = client3.version
                 logging.info('Found Helm Version {}'.format(detected_version))


### PR DESCRIPTION
This fixes an issue where when helm3 is installed, the helm2 client version check would fail and prevent the helm3 client version check from ever being run.  The combination of `HelmClientException` and `HelmVersionException` in the `except` will make it so it proceeds.