### PR TITLE
Fixes #173. Regex the comments out before interpolating env vars.

### DIFF
--- a/end_to_end_testing/setup_common.sh
+++ b/end_to_end_testing/setup_common.sh
@@ -15,7 +15,7 @@ sudo cp /tmp/binaries/reckoner-linux-amd64 /usr/local/bin/reckoner
 reckoner version
 
 echo "Installing Kind"
-curl -sLO https://github.com/kubernetes-sigs/kind/releases/download/v0.4.0/kind-linux-amd64
+curl -sLO https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64
 chmod 0755 kind-linux-amd64
 sudo mv kind-linux-amd64 /usr/local/bin/kind
 kind version
@@ -27,9 +27,7 @@ sudo mv kubectl /usr/local/bin/
 kubectl version --client
 
 echo "Creating Kubernetes Cluster with Kind"
-kind create cluster --wait=90s --image kindest/node:v1.14.3
+kind create cluster --wait=90s --image kindest/node:v1.15.7@sha256:e2df133f80ef633c53c0200114fce2ed5e1f6947477dbc83261a6a921169488d
 docker ps -a
 
-echo "Setting up kubecfg"
-cp "$(kind get kubeconfig-path --name=kind)" ~/.kube/config
 kubectl version

--- a/end_to_end_testing/test_env_var.yml
+++ b/end_to_end_testing/test_env_var.yml
@@ -14,11 +14,15 @@ charts:
     namespace: infra
     values:
       non-used: "${myvar}"
+      comment-problem-detector:
+        # This is a comment "${this_var_should_not_be_parsed}"
+        - test-value
   check-set-values:
     repository: stable
     chart: nginx-ingress
-    namespace: infra
+    namespace: infra # ${dont_parse_me}
     set-values:
+      # This comment ${should_also_not_be_parsed}
       non-used: "${myvar}"
   check-values-strings:
     repository: stable

--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -16,6 +16,7 @@
 
 import logging
 import os
+import re
 
 from .kube import create_namespace, list_namespace_names
 from tempfile import NamedTemporaryFile as tempfile
@@ -377,11 +378,8 @@ class Chart(object):
             with tempfile('w+t', suffix=".yml", delete=False) as temp_yaml:
                 # load up the self.values yaml string
 
-                # HACK: Ugly hack to get rid of all comments in a temp yaml file so we don't try to env var replace vars in comments
-                yaml_without_comments = yaml_handler.copy_without_comments(self.values)
-
                 # write the yaml to a string
-                yaml_output = yaml_handler.dump(yaml_without_comments)
+                yaml_output = yaml_handler.dump(self.values)
 
                 # read the yaml_output and interpolate any variables
                 yaml_output = self._interpolate_env_vars_from_string(yaml_output)
@@ -409,8 +407,11 @@ class Chart(object):
 
     @staticmethod
     def _interpolate_env_vars_from_string(original_string: str) -> str:
+
+        # We should never interpolate an env var in a comment. Strip comments from the string before interpolating.
+        comments_removed = re.sub(r'([^#]*)(#.*)', r"\g<1>", original_string)
         try:
-            interpolated_string = Template(original_string).substitute(os.environ)
+            interpolated_string = Template(comments_removed).substitute(os.environ)
         except KeyError as err:
             raise Exception("Missing required environment variable: {}".format(", ".join(err.args)))
         except ValueError:

--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -409,7 +409,7 @@ class Chart(object):
     def _interpolate_env_vars_from_string(original_string: str) -> str:
 
         # We should never interpolate an env var in a comment. Strip comments from the string before interpolating.
-        comments_removed = re.sub(r'([^#]*)(#.*)', r"\g<1>", original_string)
+        comments_removed = re.sub(r'([^#]*)(#.*)', r'\g<1>', original_string)
         try:
             interpolated_string = Template(comments_removed).substitute(os.environ)
         except KeyError as err:

--- a/reckoner/yaml/handler.py
+++ b/reckoner/yaml/handler.py
@@ -16,7 +16,6 @@ from ruamel.yaml import YAML
 from ruamel.yaml.constructor import DuplicateKeyError
 from reckoner.exception import ReckonerConfigException
 import logging
-from copy import deepcopy
 from io import BufferedReader, StringIO
 
 
@@ -46,16 +45,6 @@ class Handler(object):
         temp_file = StringIO()
         cls.yaml.dump(data, temp_file)
         return temp_file.getvalue()
-
-    @staticmethod
-    def copy_without_comments(o: dict):
-        if hasattr(o, '_yaml_comment'):
-            r = deepcopy(o)
-            r._yaml_comment.comment = None
-            r._yaml_comment._items = {}
-            return r
-        else:
-            return deepcopy(o)
 
 
 def _clean_duplicate_key_message(msg: str):

--- a/tests/test_course.yml
+++ b/tests/test_course.yml
@@ -10,6 +10,13 @@ minimum_versions: #set minimum version requirements here
 helm_args:
   - --recreate-pods
 charts:
+  values-test-deeply-nested-comment:
+    repository: stable
+    version: "0.0.0"
+    values:
+      args:
+        # Comment ${dne}
+        - test
   cluster-autoscaler:
     repository: stable
     version: "0.2.1"
@@ -52,4 +59,4 @@ charts:
   redis:
     namespace: redis-test-namespace
     set-values:
-      test_environ_var: ${test_environ_var}
+      test_environ_var: ${test_environ_var} # test "${no_env_var}"


### PR DESCRIPTION
- update to kind 0.7.0 for e2e tests
- update kube to 1.15.7
- add e2e and unit testing coverage for deeply-nested comments inside of `values`