### PR TITLE
Ejether/chart level namespace manager

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ We'll be breaking this documentation down into sections to make reference easier
 # Top Level Keys
 - `namespace` _(string)_ _**(required)**_  
     The default namespace for any chart definitions in your course
+- `namespace_management` _(object)_ **(optional)** a structure the defines default annotations and labels to the namespaces that Reckoner will create
 - `charts` _(object)_ _**(required)**_  
     The charts and chart definitions to install with this course, must be alphanumeric between 1 and 63 characters (also allows underscore and dash)
 - `repositories` _(object)_  
@@ -26,6 +27,15 @@ We'll be breaking this documentation down into sections to make reference easier
 Example:
 ```yaml
 namespace: kube-system
+namespace_management:
+  default:
+    metadata:
+      annotations:
+        ManagedBy: com.fairwinds.reckoner
+      labels:
+        labelName: labelValue
+    settings:
+      overwrite: True
 context: my-kube-cluster
 repositories:
   stable:
@@ -41,6 +51,7 @@ The `charts` block in your course define all the charts you'd like to install an
 
 - `namespace` _(string)_  
     The namespace in which to install this chart (overrides root level `namespace` definition)
+- `namespace_management` _(object)_ **(optional)** a structure the defines default annotations and labels to the namespace that Reckoner will create. Structure matches the `default` structure at the top level `namespace_managment` block.
 - `chart` _(string)_  
     The name of the chart in the remote chart respository (example: `nginx-ingress`) and when using git repositories this is the folder in which the chart files exist
 - `repository` _(string)_ or _(object)_  
@@ -64,8 +75,17 @@ The `charts` block in your course define all the charts you'd like to install an
 ...
 charts:
   my-release-name:
-    chart: ngixn-ingress
+    chart: nginx-ingress
     version: "0.25.1"
+    namespace: nginx-ingress
+    namespace_management:
+      metadata:
+        annotations:
+          ManagedBy: com.fairwinds.reckoner
+        labels:
+          labelName: labelValue
+      settings:
+        overwrite: True
     repository: stable
     hooks:
       pre_install: echo hi
@@ -135,6 +155,22 @@ minimum_versions:
   reckoner: 2.1.0
 ```
 
+## Namespace Management
+
+When you wish to manage annotations or labels for the namespaces you are installing into with Reckoner, this `namespace_management` block to define default namespace metadata and the whether or not it should overwrite the values that exist.
+
+Example:
+```yaml
+namespace_management:
+  default:
+    metadata:
+      annotations:
+        ManagedBy: com.fairwinds.reckoner
+      labels:
+        labelName: labelValue
+    settings:
+      overwrite: True
+```
 
 # CLI Usage
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,7 @@ The `charts` block in your course define all the charts you'd like to install an
 
 - `namespace` _(string)_  
     The namespace in which to install this chart (overrides root level `namespace` definition)
-- `namespace_management` _(object)_ **(optional)** a structure the defines default annotations and labels to the namespace that Reckoner will create. Structure matches the `default` structure at the top level `namespace_managment` block.
+- `namespace_management` _(object)_ **(optional)** a structure the defines default annotations and labels to the namespace that Reckoner will create. Structure matches the `default` structure at the top level `namespace_management` block.
 - `chart` _(string)_  
     The name of the chart in the remote chart respository (example: `nginx-ingress`) and when using git repositories this is the folder in which the chart files exist
 - `repository` _(string)_ or _(object)_  

--- a/end_to_end_testing/run_end_to_end.sh
+++ b/end_to_end_testing/run_end_to_end.sh
@@ -547,6 +547,20 @@ function e2e_test_does_not_overwrite_namespace_management(){
     fi
 }
 
+function e2e_test_annotate_namespace_defined_on_chart(){
+    if ! reckoner plot test_annotate_namespace_defined_on_chart.yml; then
+        mark_failed "${FUNCNAME[0]}" "Expected to run without an error."
+    fi
+
+    if ! namespace_has_annotation_with_value annotatednamespaceagain defined inchart; then
+        mark_failed "${FUNCNAME[0]}" "Expected annotation on namespace."
+    fi
+
+    if ! namespace_has_label_with_value annotatednamespaceagain label onchart; then
+        mark_failed "${FUNCNAME[0]}" "Expected label on namespace."
+    fi
+}
+
 function run_test() {
     local test_name
     test_name="${1}"

--- a/end_to_end_testing/run_end_to_end.sh
+++ b/end_to_end_testing/run_end_to_end.sh
@@ -548,7 +548,7 @@ function e2e_test_does_not_overwrite_namespace_management(){
 }
 
 function e2e_test_annotate_namespace_defined_on_chart(){
-    if ! reckoner plot test_annotate_namespace_defined_on_chart.yml; then
+    if ! reckoner --log-level=DEBUG plot test_annotate_namespace_defined_on_chart.yml; then
         mark_failed "${FUNCNAME[0]}" "Expected to run without an error."
     fi
 

--- a/end_to_end_testing/test_annotate_namespace_defined_on_chart.yml
+++ b/end_to_end_testing/test_annotate_namespace_defined_on_chart.yml
@@ -16,8 +16,9 @@ charts:
     repository: stable
     chart: nginx-ingress
     namespace: annotatednamespaceagain
-    namespace_managment:
-      annotations: 
-        defined: inchart
-      label:
-        label: onchart
+    namespace_management:
+      metadata:
+        annotations: 
+          defined: inchart
+        labels:
+          label: onchart

--- a/end_to_end_testing/test_annotate_namespace_defined_on_chart.yml
+++ b/end_to_end_testing/test_annotate_namespace_defined_on_chart.yml
@@ -1,0 +1,23 @@
+namespace: annotatednamespace #namespace to install the chart in, defaults to 'kube-system'
+repositories:
+  test_repo:
+    url: https://kubernetes-charts.storage.googleapis.com
+  incubator:
+    url: https://kubernetes-charts-incubator.storage.googleapis.com
+  fairwinds-stable:
+    url: https://charts.fairwinds.com/stable
+  fairwinds-incubator:
+    url: https://charts.fairwinds.com/incubator
+minimum_versions: #set minimum version requirements here
+  helm: 0.0.0
+  reckoner: 0.0.0
+charts:
+  namespace-test:
+    repository: stable
+    chart: nginx-ingress
+    namespace: annotatednamespaceagain
+    namespace_managment:
+      annotations: 
+        defined: inchart
+      label:
+        label: onchart

--- a/end_to_end_testing/test_default_namespace_annotation_and_labels.yml
+++ b/end_to_end_testing/test_default_namespace_annotation_and_labels.yml
@@ -1,0 +1,27 @@
+namespace: annotatednamespace #namespace to install the chart in, defaults to 'kube-system'
+namespace_management:
+  default:
+    metadata:
+      annotations:
+        reckoner: rocks
+      labels:
+        rocks: reckoner
+    settings:
+      overwrite: True
+repositories:
+  test_repo:
+    url: https://kubernetes-charts.storage.googleapis.com
+  incubator:
+    url: https://kubernetes-charts-incubator.storage.googleapis.com
+  fairwinds-stable:
+    url: https://charts.fairwinds.com/stable
+  fairwinds-incubator:
+    url: https://charts.fairwinds.com/incubator
+minimum_versions: #set minimum version requirements here
+  helm: 0.0.0
+  reckoner: 0.0.0
+charts:
+  namespace-test:
+    repository: stable
+    chart: nginx-ingress
+    namespace: annotatednamespace

--- a/end_to_end_testing/test_does_not_overwrite_namespace_annotation_and_labels.yml
+++ b/end_to_end_testing/test_does_not_overwrite_namespace_annotation_and_labels.yml
@@ -1,0 +1,27 @@
+namespace: annotatednamespace #namespace to install the chart in, defaults to 'kube-system'
+namespace_management:
+  default:
+    metadata:
+      annotations:
+        reckoner: doesnotrockalsoshoulenotbewritten
+      labels:
+        rocks: reckonerstillshouldnotbewritten
+    settings:
+      overwrite: False
+repositories:
+  test_repo:
+    url: https://kubernetes-charts.storage.googleapis.com
+  incubator:
+    url: https://kubernetes-charts-incubator.storage.googleapis.com
+  fairwinds-stable:
+    url: https://charts.fairwinds.com/stable
+  fairwinds-incubator:
+    url: https://charts.fairwinds.com/incubator
+minimum_versions: #set minimum version requirements here
+  helm: 0.0.0
+  reckoner: 0.0.0
+charts:
+  namespace-test:
+    repository: stable
+    chart: nginx-ingress
+    namespace: annotatednamespace

--- a/end_to_end_testing/test_overwrite_namespace_annotation_and_labels.yml
+++ b/end_to_end_testing/test_overwrite_namespace_annotation_and_labels.yml
@@ -1,0 +1,27 @@
+namespace: annotatednamespace #namespace to install the chart in, defaults to 'kube-system'
+namespace_management:
+  default:
+    metadata:
+      annotations:
+        reckoner: doesnotrock
+      labels:
+        rocks: reckonerstill
+    settings:
+      overwrite: True
+repositories:
+  test_repo:
+    url: https://kubernetes-charts.storage.googleapis.com
+  incubator:
+    url: https://kubernetes-charts-incubator.storage.googleapis.com
+  fairwinds-stable:
+    url: https://charts.fairwinds.com/stable
+  fairwinds-incubator:
+    url: https://charts.fairwinds.com/incubator
+minimum_versions: #set minimum version requirements here
+  helm: 0.0.0
+  reckoner: 0.0.0
+charts:
+  namespace-test:
+    repository: stable
+    chart: nginx-ingress
+    namespace: annotatednamespace

--- a/reckoner/assets/course.schema.json
+++ b/reckoner/assets/course.schema.json
@@ -57,6 +57,27 @@
                     "namespace": {
                         "type": "string"
                     },
+                    "namespace_management": {
+                        "type": "object",
+                        "additionalProperties": false, 
+                        "properties": {
+                            "metadata": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "annotations": {
+                                        "type": "object"
+                                    },
+                                    "labels": {
+                                        "type": "object"
+                                    }
+                                }
+                            },
+                            "settings": {
+                                "type": "object"
+                            }
+                        }
+                    },
                     "chart": {
                         "type": "string"
                     },
@@ -108,6 +129,33 @@
         },
         "namespace": {
             "type": "string"
+        },
+        "namespace_management": {
+            "type": "object",
+            "additionalProperties": false, 
+            "properties": {
+                "default": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "metadata": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "labels": {
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "settings": {
+                            "type": "object"
+                        }
+                    }
+                }
+            }
         },
         "charts": {
             "$ref": "#/definitions/chart"

--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -90,6 +90,7 @@ class Chart(object):
         self.args = []
 
         self._namespace = self._chart.get('namespace')
+        self._namespace_management = self._chart.get('namespace_management', {})
         self._context = self._chart.get('context')
         value_strings = self._chart.get('values-strings', {})
         self._chart['values_strings'] = value_strings
@@ -274,7 +275,7 @@ class Chart(object):
         if self.namespace is None:
             self._namespace = default_namespace
 
-        # Set the namespace-managment settings
+        # Set the namespace-management settings
         if self.namespace_management is None:
             self._namespace_management = default_namespace_management
 

--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -90,7 +90,7 @@ class Chart(object):
         self.args = []
 
         self._namespace = self._chart.get('namespace')
-        self._namespace_management = self._chart.get('namespace_management', {})
+        self._namespace_management = self._chart.get('namespace_management')
         self._context = self._chart.get('context')
         value_strings = self._chart.get('values-strings', {})
         self._chart['values_strings'] = value_strings

--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -14,11 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
+
 import os
 import re
+import logging
+import traceback
 
-from .kube import create_namespace, list_namespace_names
+from .kube import NamespaceManager
 from tempfile import NamedTemporaryFile as tempfile
 from .yaml.handler import Handler as yaml_handler
 
@@ -141,6 +143,11 @@ class Chart(object):
         return self._namespace
 
     @property
+    def namespace_management(self):
+        """ Namespace to install the course chart """
+        return self._namespace_management
+
+    @property
     def context(self):
         """ Namespace to install the course chart """
         return self._context
@@ -243,41 +250,41 @@ class Chart(object):
             except ReckonerCommandException as error:
                 logging.warn("Unable to update chart dependencies: {}".format(error.stderr))
 
-    def create_namespace_if_needed(self):
+    def manage_namespace(self):
         """ Creates the charts specified namespace if it does not already exist
         Requires `self.config.create_namespace` to true. Caches the existing namespace list
         in the self.config option to avoid going back to the api for each chart. 
         """
-        
-        if self.config.create_namespace:
-            if self.config.cluster_namespaces is None:
-                self.config.cluster_namespaces = list_namespace_names()
 
-            if self.namespace not in self.config.cluster_namespaces and not self.dryrun:
-                if create_namespace(self.namespace):
-                    logging.info('Namespace {} not found. Creating it now.'.format(self.namespace))
-                    self.config.cluster_namespaces.append(self.namespace)
+        if self.config.create_namespace and not self.dryrun:
+            nsm = NamespaceManager(self.namespace, self.namespace_management)
+            nsm.create_and_manage()
 
-    def install(self, namespace=None, context=None) -> None:
+    def install(self, default_namespace=None, default_namespace_management={}, context=None) -> None:
         """
         Description:
         - Upgrade --install the course chart
 
         Arguments:
-        - namespace (string). Passed in but will be overridden by Chart().namespace if set
+        - default_namespace (string). Passed in but will be overridden by Chart().namespace if set
+        - default_namespace_management_settings (dictionary). Passed in but will be overridden by Chart().namespace_management_settings if set
         """
 
         # Set the namespace
         if self.namespace is None:
-            self._namespace = namespace
+            self._namespace = default_namespace
+
+        # Set the namespace-managment settings
+        if self.namespace_management is None:
+            self._namespace_management = default_namespace_management
 
         # Set the context
         if self.context is None:
             self._context = context
-
         # Try to run the install process for mark the result as failed
+
         try:
-            self.create_namespace_if_needed()
+            self.manage_namespace()
 
             # Fire the pre_install_hook
             self.pre_install_hook()
@@ -312,6 +319,7 @@ class Chart(object):
         except Exception as err:
             logging.debug("Saving encountered error to chart result. See Below:")
             logging.debug("{}".format(err))
+            logging.debug(traceback.format_exc())
             self.result.failed = True
             self.result.error_reason = err
             raise err

--- a/reckoner/course.py
+++ b/reckoner/course.py
@@ -117,6 +117,17 @@ class Course(object):
         """ Course repositories """
         return self._repositories
 
+    @property
+    def namespace_management(self):
+        """ The default namespace manager block from the course if it exists
+        Otherwise, returns {} """
+        _namespace_management = self._dict.get('namespace_management')
+
+        if _namespace_management is None:
+            return {}
+        else:
+            return _namespace_management.get('default', {})
+
     def __getattr__(self, key):
         return self._dict.get(key)
 
@@ -130,17 +141,10 @@ class Course(object):
         for chart in charts_to_install:
             logging.info("Installing {}".format(chart.release_name))
             try:
-                if self.namespace_management is None:
-                    default_namespace_management = {}
-                else:
-                    default_namespace_management = self.namespace_management.get(
-                        'default',
-                        {}
-                    )
 
                 chart.install(
                     default_namespace=self.namespace,
-                    default_namespace_management=default_namespace_management,
+                    default_namespace_management=self.namespace_management,
                     context=self.context
                 )
             except (Exception, ReckonerCommandException) as e:

--- a/reckoner/course.py
+++ b/reckoner/course.py
@@ -130,8 +130,22 @@ class Course(object):
         for chart in charts_to_install:
             logging.info("Installing {}".format(chart.release_name))
             try:
-                chart.install(namespace=self.namespace, context=self.context)
+                if self.namespace_management is None:
+                    default_namespace_management = {}
+                else:
+                    default_namespace_management = self.namespace_management.get(
+                        'default',
+                        {}
+                    )
+
+                chart.install(
+                    default_namespace=self.namespace,
+                    default_namespace_management=default_namespace_management,
+                    context=self.context
+                )
             except (Exception, ReckonerCommandException) as e:
+                import traceback
+                logging.debug(print(traceback.format_exc()))
                 if type(e) == ReckonerCommandException:
                     logging.error(e.stderr)
                 if type(e) == Exception:

--- a/reckoner/kube.py
+++ b/reckoner/kube.py
@@ -1,47 +1,133 @@
 
+import sys
 import logging
 import traceback
 
 from kubernetes import client, config
 
 
-def create_namespace(namespace):
-    """ Create a namespace in the configured kubernetes cluster if it does not already exist
+class NamespaceManager(object):
 
-    Arguments:
-
-    namespace: The namespace to create
-
-    Returns True on success
-    Raises error in case of failure
-
-    """
-    try:
-        config.load_kube_config()
-        v1 = client.CoreV1Api()
-        response = v1.create_namespace(
-            client.V1Namespace(
-                metadata=client.V1ObjectMeta(name=namespace)
-            )
+    def __init__(self, namespace_name, namespace_management) -> None:
+        """ Manages a namespace for the chart
+        Accepts:
+        - namespace: Which may be a string or a dictionary
+        """
+        self._namespace_name = namespace_name
+        self._metadata = namespace_management.get('metadata', {})
+        self._overwrite = namespace_management.get(
+            'settings',
+            {}
+        ).get(
+            'overwrite',
+            False
         )
-        return True
-    except Exception as e:
-        logging.error("Unable to create namespace in cluster! {}".format(e))
-        logging.debug(traceback.format_exc())
-        raise e
+        self.__load_config()
 
+    @property
+    def namespace_name(self) -> str:
+        """ Name of the namespace we are managing """
+        return self._namespace_name
 
-def list_namespace_names():
-    """ Lists namespaces in the configured kubernetes cluster.
-    No arguments
-    Returns list
-    """
-    try:
-        config.load_kube_config()
-        v1 = client.CoreV1Api()
-        namespaces = v1.list_namespace()
-        return [namespace.metadata.name for namespace in namespaces.items]
-    except Exception as e:
-        logging.error("Unable to get namespaces in cluster! {}".format(e))
-        logging.debug(traceback.format_exc())
-        raise e
+    @property
+    def namespace(self) -> str:
+        """ Namespace object we are managing 
+        https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1Namespace.md"""
+        return self._namespace
+
+    @property
+    def metadata(self) -> dict:
+        """ List of metadata settings parsed from the
+        from the chart and course """
+        return self._metadata
+
+    @property
+    def overwrite(self) -> bool:
+        """ List of metadata settings parsed from the
+        from the chart and course """
+        return self._overwrite
+
+    def __load_config(self):
+        """ Protected method do load kubernetes config"""
+        try:
+            config.load_kube_config()
+            self.v1client = client.CoreV1Api()
+        except Exception as e:
+            logging.error('Unable to load kuberentes configuration')
+            logging.debug(traceback.format_exc())
+            raise e
+
+    def create_and_manage(self):
+        """ Create namespace and patch metadata """
+        self._namespace = self.create()
+        self.patch_metadata()
+
+    def patch_metadata(self):
+        """ Patch namepace with metadata respecting overwrite setting.
+        Returns True on success
+        Raises error on failure
+        """
+        if self.overwrite:
+            patch_metadata = self.metadata
+            logging.debug("Overwiting Namespace Metadata")
+        else:
+            annotations = {}
+            for annotation_name, annotation_value in self.metadata.get('annotations').items():
+                try:
+                    self.namespace.metadata.annotations[annotation_name]
+                except (TypeError, KeyError):
+                    annotations[annotation_name] = annotation_value
+
+            labels = {}
+            for label_name, label_value in self.metadata.get('labels').items():
+                try:
+                    self.namespace.metadata.labels[label_name]
+                except (TypeError, KeyError):
+                    labels[label_name] = label_value
+
+            patch_metadata = {'annotations': annotations, 'labels': labels}
+        logging.debug("Patch Metadata: {}".format(patch_metadata))
+        patch = {'metadata': patch_metadata}
+        res = self.v1client.patch_namespace(self.namespace_name, patch)
+
+    def create(self):
+        """ Create a namespace in the configured kubernetes cluster if it does not already exist
+
+        Arguments:
+        None
+
+        Returns Namespace
+        Raises error in case of failure
+
+        """
+        _namespaces = [namespace for namespace in self.cluster_namespaces if namespace.metadata.name == self.namespace_name]
+
+        if _namespaces == []:
+            logging.info('Namespace {} not found. Creating it now.'.format(self.namespace_name))
+            try:
+                return self.v1client.create_namespace(
+                    client.V1Namespace(
+                        metadata=client.V1ObjectMeta(name=self.namespace_name)
+                    )
+                )
+
+            except Exception as e:
+                logging.error("Unable to create namespace in cluster! {}".format(e))
+                logging.debug(traceback.format_exc())
+                raise e
+        else:
+            return _namespaces[0]
+
+    @property
+    def cluster_namespaces(self) -> list:
+        """ Lists namespaces in the configured kubernetes cluster.
+        No arguments
+        Returns list of namespace objects
+        """
+        try:
+            namespaces = self.v1client.list_namespace()
+            return [namespace for namespace in namespaces.items]
+        except Exception as e:
+            logging.error("Unable to get namespaces in cluster! {}".format(e))
+            logging.debug(traceback.format_exc())
+            raise e

--- a/reckoner/kube.py
+++ b/reckoner/kube.py
@@ -85,14 +85,14 @@ class NamespaceManager(object):
             logging.debug("Overwiting Namespace Metadata")
         else:
             annotations = {}
-            for annotation_name, annotation_value in self.metadata.get('annotations').items():
+            for annotation_name, annotation_value in self.metadata.get('annotations', {}).items():
                 try:
                     self.namespace.metadata.annotations[annotation_name]
                 except (TypeError, KeyError):
                     annotations[annotation_name] = annotation_value
 
             labels = {}
-            for label_name, label_value in self.metadata.get('labels').items():
+            for label_name, label_value in self.metadata.get('labels', {}).items():
                 try:
                     self.namespace.metadata.labels[label_name]
                 except (TypeError, KeyError):

--- a/reckoner/kube.py
+++ b/reckoner/kube.py
@@ -1,3 +1,16 @@
+# Copyright 2019 FairwindsOps Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import sys
 import logging

--- a/reckoner/kube.py
+++ b/reckoner/kube.py
@@ -61,12 +61,12 @@ class NamespaceManager(object):
         return self._overwrite
 
     def __load_config(self):
-        """ Protected method do load kubernetes config"""
+        """ Protected method to load kubernetes config"""
         try:
             config.load_kube_config()
             self.v1client = client.CoreV1Api()
         except Exception as e:
-            logging.error('Unable to load kuberentes configuration')
+            logging.error('Unable to load kubernetes configuration')
             logging.debug(traceback.format_exc())
             raise e
 
@@ -76,13 +76,13 @@ class NamespaceManager(object):
         self.patch_metadata()
 
     def patch_metadata(self):
-        """ Patch namepace with metadata respecting overwrite setting.
+        """ Patch namespace with metadata respecting overwrite setting.
         Returns True on success
         Raises error on failure
         """
         if self.overwrite:
             patch_metadata = self.metadata
-            logging.debug("Overwiting Namespace Metadata")
+            logging.debug("Overwriting Namespace Metadata")
         else:
             annotations = {}
             for annotation_name, annotation_value in self.metadata.get('annotations', {}).items():

--- a/reckoner/tests/namespace_manager_mock.py
+++ b/reckoner/tests/namespace_manager_mock.py
@@ -1,0 +1,82 @@
+
+from kubernetes import client, config
+
+
+class NamespaceManagerMock(object):
+
+    def __init__(self, namespace_name='', namespace_management={}) -> None:
+        """ Manages a namespace for the chart
+        Accepts:
+        - namespace: Which may be a string or a dictionary
+        """
+        self._namespace_name = namespace_name
+        self._metadata = namespace_management.get('metadata', {})
+        self._overwrite = namespace_management.get(
+            'settings',
+            {}
+        ).get(
+            'overwrite',
+            False
+        )
+        self.__load_config()
+
+    @property
+    def namespace_name(self) -> str:
+        """ Name of the namespace we are managing """
+        return self._namespace_name
+
+    @property
+    def namespace(self) -> str:
+        """ Namespace object we are managing 
+        https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1Namespace.md"""
+        return self._namespace
+
+    @property
+    def metadata(self) -> dict:
+        """ List of metadata settings parsed from the
+        from the chart and course """
+        return self._metadata
+
+    @property
+    def overwrite(self) -> bool:
+        """ List of metadata settings parsed from the
+        from the chart and course """
+        return self._overwrite
+
+    def __load_config(self):
+        """ Protected method do load kubernetes config"""
+        pass
+
+    def create_and_manage(self):
+        """ Create namespace and patch metadata """
+        self._namespace = self.create()
+        self.patch_metadata()
+
+    def patch_metadata(self):
+        """ Patch namepace with metadata respecting overwrite setting.
+        Returns True on success
+        Raises error on failure
+        """
+        pass
+
+    def create(self):
+        """ Create a namespace in the configured kubernetes cluster if it does not already exist
+
+        Arguments:
+        None
+
+        Returns Namespace
+        Raises error in case of failure
+
+        """
+        return client.V1Namespace(
+            metadata=client.V1ObjectMeta(name=self.namespace_name)
+        )
+
+    @property
+    def cluster_namespaces(self) -> list:
+        """ Lists namespaces in the configured kubernetes cluster.
+        No arguments
+        Returns list of namespace objects
+        """
+        return []

--- a/reckoner/tests/test_chart.py
+++ b/reckoner/tests/test_chart.py
@@ -21,6 +21,8 @@ from reckoner.exception import ReckonerCommandException
 from reckoner.yaml.handler import Handler
 from io import StringIO
 
+from .namespace_manager_mock import NamespaceManagerMock
+
 
 @mock.patch('reckoner.chart.Repository')
 @mock.patch('reckoner.chart.Config')
@@ -218,7 +220,7 @@ class TestCharts(unittest.TestCase):
         chart._check_env_vars()
         self.assertEqual(chart.args[0], 'thing=$(environVar)')
 
-    @mock.patch('reckoner.chart.NamespaceManager.create_and_manage', mock.MagicMock(return_value=True))
+    @mock.patch('reckoner.chart.NamespaceManager', NamespaceManagerMock)
     @mock.patch('reckoner.chart.Config', autospec=True)
     @mock.patch('reckoner.chart.Repository')
     def test_chart_install(self, repositoryMock, chartConfigMock):
@@ -240,7 +242,7 @@ class TestCharts(unittest.TestCase):
         upgrade_call = helm_client_mock.upgrade.call_args
         self.assertEqual(upgrade_call[0][0], ['nameofchart', '', '--namespace', 'fakenamespace'])
 
-    @mock.patch('reckoner.chart.NamespaceManager.create_and_manage', mock.MagicMock(return_value=True))
+    @mock.patch('reckoner.chart.NamespaceManager', NamespaceManagerMock)
     @mock.patch('reckoner.chart.Config', autospec=True)
     @mock.patch('reckoner.chart.Repository')
     def test_chart_install_with_plugin(self, repositoryMock, chartConfigMock):

--- a/reckoner/tests/test_chart.py
+++ b/reckoner/tests/test_chart.py
@@ -218,8 +218,7 @@ class TestCharts(unittest.TestCase):
         chart._check_env_vars()
         self.assertEqual(chart.args[0], 'thing=$(environVar)')
 
-    @mock.patch('reckoner.chart.create_namespace', mock.MagicMock(return_value=True))
-    @mock.patch('reckoner.chart.list_namespace_names', mock.MagicMock(return_value=[]))
+    @mock.patch('reckoner.chart.NamespaceManager.create_and_manage', mock.MagicMock(return_value=True))
     @mock.patch('reckoner.chart.Config', autospec=True)
     @mock.patch('reckoner.chart.Repository')
     def test_chart_install(self, repositoryMock, chartConfigMock):
@@ -241,8 +240,7 @@ class TestCharts(unittest.TestCase):
         upgrade_call = helm_client_mock.upgrade.call_args
         self.assertEqual(upgrade_call[0][0], ['nameofchart', '', '--namespace', 'fakenamespace'])
 
-    @mock.patch('reckoner.chart.create_namespace', mock.MagicMock(return_value=True))
-    @mock.patch('reckoner.chart.list_namespace_names', mock.MagicMock(return_value=[]))
+    @mock.patch('reckoner.chart.NamespaceManager.create_and_manage', mock.MagicMock(return_value=True))
     @mock.patch('reckoner.chart.Config', autospec=True)
     @mock.patch('reckoner.chart.Repository')
     def test_chart_install_with_plugin(self, repositoryMock, chartConfigMock):

--- a/reckoner/tests/test_chart.py
+++ b/reckoner/tests/test_chart.py
@@ -26,9 +26,6 @@ from .namespace_manager_mock import NamespaceManagerMock
 
 @mock.patch('reckoner.chart.Repository')
 @mock.patch('reckoner.chart.Config')
-# I have to strictly design the mock for Reckoner due to the nature of the
-# key/val class setup. If the class actually had attributes then this
-# would be more easily mockable
 @mock.patch('reckoner.chart.call')
 class TestChartHooks(unittest.TestCase):
 
@@ -167,13 +164,6 @@ class TestChartHooks(unittest.TestCase):
         chart.run_hook('pre_install')
         mock_cmd_call.assert_called_once()
 
-
-# @mock.patch('reckoner.chart.Repository')
-# @mock.patch('reckoner.chart.Config')
-# # I have to strictly design the mock for Reckoner due to the nature of the
-# # key/val class setup. If the class actually had attributes then this
-# # would be more easily mockable
-# @mock.patch('reckoner.chart.call')
 class TestCharts(unittest.TestCase):
     """Test charts"""
 

--- a/reckoner/tests/test_course.py
+++ b/reckoner/tests/test_course.py
@@ -255,7 +255,7 @@ class TestCourse(unittest.TestCase):
             default_namespace_management=c.namespace_management
         )
 
-    def test_course_namespace_and_managment_handling(self, mockGetHelm, mockYAML):
+    def test_course_namespace_and_management_handling(self, mockGetHelm, mockYAML):
         """Assure that course replaces strings with object settings for chart repository settings"""
         course = mockYAML.load.return_value = self.course_yaml
         course['namespace'] = "test-namespace"

--- a/reckoner/tests/test_course.py
+++ b/reckoner/tests/test_course.py
@@ -21,6 +21,7 @@ from reckoner.exception import ReckonerException
 
 from .namespace_manager_mock import NamespaceManagerMock
 
+
 @mock.patch('reckoner.repository.Repository', autospec=True)
 @mock.patch('reckoner.course.sys')
 @mock.patch('reckoner.course.yaml_handler', autospec=True)
@@ -79,7 +80,7 @@ class TestMinVersion(unittest.TestCase):
 
 class TestIntegrationWithChart(unittest.TestCase):
 
-    @mock.patch('reckoner.chart.NamespaceManager', NamespaceManagerMock)    
+    @mock.patch('reckoner.chart.NamespaceManager', NamespaceManagerMock)
     @mock.patch('reckoner.chart.Config', autospec=True)
     @mock.patch('reckoner.chart.call', autospec=True)
     @mock.patch('reckoner.repository.Repository', autospec=True)
@@ -229,5 +230,85 @@ class TestCourse(unittest.TestCase):
         # Assert that third-chart is reconciled to settings from repositories block
         self.assertDictEqual(course['charts']['third-chart']['repository'], course['repositories']['stablez'])
 
-
 # TODO: Add test for calling plot against a chart that doesn't exist in your course.yml
+
+    def test_course_namespace_and_without_namespace_management_handling(self, mockGetHelm, mockYAML):
+        """Assure that course replaces strings with object settings for chart repository settings"""
+        course = mockYAML.load.return_value = self.course_yaml
+        course['namespace'] = "test-namespace"
+
+        # Mock out the repository helm client
+        with mock.patch('reckoner.repository.HelmClient', mockGetHelm):
+            # Run the course to convert the chart['first-chart']['repository'] reference
+            c = Course(None)
+
+        # Assert the chart namespace is string
+        self.assertIsInstance(course['namespace'], str)
+
+        # Assert that the dict for the namespace manager is the same after course loads
+        # expect the first chart install to bubble up an error
+        chart = mock.MagicMock()
+        c.install_charts([chart])
+        chart.install.assert_called_with(
+            context=c.context,
+            default_namespace=c.namespace,
+            default_namespace_management=c.namespace_management
+        )
+
+    def test_course_namespace_and_managment_handling(self, mockGetHelm, mockYAML):
+        """Assure that course replaces strings with object settings for chart repository settings"""
+        course = mockYAML.load.return_value = self.course_yaml
+        course['namespace'] = "test-namespace"
+        course['namespace_management'] = {
+            "default": {
+                "metadata": {
+                    "annotations": {
+                        "a-one": "a1",
+                        "a-two": "a2"
+                    },
+                    "labels": {
+                        "l-one": "l1",
+                        "l-two": "l2",
+                    }
+                },
+                "settings": {
+                    "overwrite": True
+                }
+            }
+        }
+        
+        # Mock out the repository helm client
+        with mock.patch('reckoner.repository.HelmClient', mockGetHelm):
+            # Run the course to convert the chart['first-chart']['repository'] reference
+            c = Course(None)
+
+        # Assert the chart namespace is string
+        self.assertIsInstance(course['namespace'], str)
+
+        # Assert that the dict for the namespace manager is the same after course loads
+        self.assertDictEqual(
+            c.namespace_management,
+            {
+                "metadata": {
+                    "annotations": {
+                        "a-one": "a1",
+                        "a-two": "a2"
+                    },
+                    "labels": {
+                        "l-one": "l1",
+                        "l-two": "l2",
+                    }
+                },
+                "settings": {
+                    "overwrite": True
+                }
+            }
+        )
+        # expect the first chart install to bubble up an error
+        chart = mock.MagicMock()
+        c.install_charts([chart])
+        chart.install.assert_called_with(
+            context=c.context,
+            default_namespace=c.namespace,
+            default_namespace_management=c.namespace_management
+        )

--- a/reckoner/tests/test_course.py
+++ b/reckoner/tests/test_course.py
@@ -19,6 +19,7 @@ from reckoner.command_line_caller import Response
 from reckoner.helm.client import HelmClientException
 from reckoner.exception import ReckonerException
 
+from .namespace_manager_mock import NamespaceManagerMock
 
 @mock.patch('reckoner.repository.Repository', autospec=True)
 @mock.patch('reckoner.course.sys')
@@ -78,7 +79,7 @@ class TestMinVersion(unittest.TestCase):
 
 class TestIntegrationWithChart(unittest.TestCase):
 
-    @mock.patch('reckoner.chart.NamespaceManager.create_and_manage', mock.MagicMock(return_value=True))
+    @mock.patch('reckoner.chart.NamespaceManager', NamespaceManagerMock)    
     @mock.patch('reckoner.chart.Config', autospec=True)
     @mock.patch('reckoner.chart.call', autospec=True)
     @mock.patch('reckoner.repository.Repository', autospec=True)

--- a/reckoner/tests/test_course.py
+++ b/reckoner/tests/test_course.py
@@ -78,8 +78,7 @@ class TestMinVersion(unittest.TestCase):
 
 class TestIntegrationWithChart(unittest.TestCase):
 
-    @mock.patch('reckoner.chart.create_namespace', mock.MagicMock(return_value=True))
-    @mock.patch('reckoner.chart.list_namespace_names', mock.MagicMock(return_value=[]))
+    @mock.patch('reckoner.chart.NamespaceManager.create_and_manage', mock.MagicMock(return_value=True))
     @mock.patch('reckoner.chart.Config', autospec=True)
     @mock.patch('reckoner.chart.call', autospec=True)
     @mock.patch('reckoner.repository.Repository', autospec=True)

--- a/reckoner/tests/test_kube.py
+++ b/reckoner/tests/test_kube.py
@@ -1,0 +1,85 @@
+# Copyright 2019 FairwindsOps Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+import unittest
+
+from reckoner.kube import NamespaceManager
+
+
+@mock.patch('reckoner.kube.client', autospec=True)
+@mock.patch('reckoner.kube.config', autospec=True)
+class TestNamespaceManager(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_full_monty(self, kube_client_mock, kube_config_mock):
+
+        settings = {
+            "metadata":
+            {
+                "annotations":
+                {
+                    "one": "1ne",
+                    "two": "2wo"
+                },
+                "labels":
+                {
+                    "one": "1ne",
+                    "two": "2wo"
+                }
+            },
+            "settings": {"overwrite": True}
+        }
+
+        _ns_manager = NamespaceManager('test', settings)
+
+        self.assertTrue(_ns_manager.overwrite)
+        self.assertEqual(_ns_manager.metadata, {
+            "annotations":
+                {
+                    "one": "1ne",
+                    "two": "2wo"
+                },
+            "labels":
+                {
+                    "one": "1ne",
+                    "two": "2wo"
+                }
+        })
+
+        self.assertEqual(_ns_manager.namespace_name, 'test')
+
+    def test_overwrite_false(self, kube_client_mock, kube_config_mock):
+
+        settings = {
+            "settings": {"overwrite": False}
+        }
+
+        _ns_manager = NamespaceManager('test', settings)
+
+        self.assertFalse(_ns_manager.overwrite)
+        self.assertEqual(_ns_manager.metadata, {})
+
+    def test_overwrite_false_when_not_specified(self, kube_client_mock, kube_config_mock):
+
+        settings = {
+            "metadata": {}
+        }
+
+        _ns_manager = NamespaceManager('test', settings)
+
+        self.assertFalse(_ns_manager.overwrite)
+        self.assertEqual(_ns_manager.metadata, {})

--- a/reckoner/tests/test_reckoner.py
+++ b/reckoner/tests/test_reckoner.py
@@ -39,6 +39,7 @@ class TestReckoner(unittest.TestCase):
 
 
 class TestReckonerInstallResults(unittest.TestCase):
+
     def test_blank_results(self):
         r = ReckonerInstallResults()
         self.assertEqual(len(r.results), 0)

--- a/tests/test_reckoner.py
+++ b/tests/test_reckoner.py
@@ -74,8 +74,7 @@ class TestReckonerAttributes(TestBase):
         self.assertTrue(hasattr(reckoner_instance, 'course'))
 
 
-@mock.patch('reckoner.chart.create_namespace', mock.MagicMock(return_value=True))
-@mock.patch('reckoner.chart.list_namespace_names', mock.MagicMock(return_value=[]))
+@mock.patch('reckoner.chart.NamespaceManager.create_and_manage', mock.MagicMock(return_value=True))
 class TestCourseMocks(unittest.TestCase):
 
     @mock.patch('reckoner.course.yaml_handler', autospec=True)
@@ -239,8 +238,7 @@ def tearDownModule():
     shutil.rmtree(test_files_path)
 
 
-@mock.patch('reckoner.chart.create_namespace', mock.MagicMock(return_value=True))
-@mock.patch('reckoner.chart.list_namespace_names', mock.MagicMock(return_value=[]))
+@mock.patch('reckoner.chart.NamespaceManager.create_and_manage', mock.MagicMock(return_value=True))
 class TestReckoner(TestBase):
     name = "test-pentagon-base"
 
@@ -264,8 +262,7 @@ class TestReckoner(TestBase):
         self.assertEqual(self.a.install(), None)
 
 
-@mock.patch('reckoner.chart.create_namespace', mock.MagicMock(return_value=True))
-@mock.patch('reckoner.chart.list_namespace_names', mock.MagicMock(return_value=[]))
+@mock.patch('reckoner.chart.NamespaceManager.create_and_manage', mock.MagicMock(return_value=True))
 class TestCourse(TestBase):
 
     @mock.patch('reckoner.course.get_helm_client', autospec=True)
@@ -299,8 +296,7 @@ class TestCourse(TestBase):
         self.assertEqual(self.c._charts_to_install, self.c.charts)
 
 
-@mock.patch('reckoner.chart.create_namespace', mock.MagicMock(return_value=True))
-@mock.patch('reckoner.chart.list_namespace_names', mock.MagicMock(return_value=[]))
+@mock.patch('reckoner.chart.NamespaceManager.create_and_manage', mock.MagicMock(return_value=True))
 class TestChart(TestBase):
 
     @mock.patch('reckoner.course.get_helm_client', autospec=True)

--- a/tests/test_reckoner.py
+++ b/tests/test_reckoner.py
@@ -25,6 +25,8 @@ import mock
 import reckoner
 import ruamel.yaml as yaml
 
+from reckoner.tests.namespace_manager_mock import NamespaceManagerMock
+
 from reckoner.reckoner import Reckoner
 from reckoner.config import Config
 from reckoner.course import Course
@@ -74,7 +76,7 @@ class TestReckonerAttributes(TestBase):
         self.assertTrue(hasattr(reckoner_instance, 'course'))
 
 
-@mock.patch('reckoner.chart.NamespaceManager.create_and_manage', mock.MagicMock(return_value=True))
+@mock.patch('reckoner.chart.NamespaceManager', NamespaceManagerMock)    
 class TestCourseMocks(unittest.TestCase):
 
     @mock.patch('reckoner.course.yaml_handler', autospec=True)
@@ -238,7 +240,7 @@ def tearDownModule():
     shutil.rmtree(test_files_path)
 
 
-@mock.patch('reckoner.chart.NamespaceManager.create_and_manage', mock.MagicMock(return_value=True))
+@mock.patch('reckoner.chart.NamespaceManager', NamespaceManagerMock)    
 class TestReckoner(TestBase):
     name = "test-pentagon-base"
 
@@ -262,7 +264,7 @@ class TestReckoner(TestBase):
         self.assertEqual(self.a.install(), None)
 
 
-@mock.patch('reckoner.chart.NamespaceManager.create_and_manage', mock.MagicMock(return_value=True))
+@mock.patch('reckoner.chart.NamespaceManager', NamespaceManagerMock)    
 class TestCourse(TestBase):
 
     @mock.patch('reckoner.course.get_helm_client', autospec=True)
@@ -296,7 +298,7 @@ class TestCourse(TestBase):
         self.assertEqual(self.c._charts_to_install, self.c.charts)
 
 
-@mock.patch('reckoner.chart.NamespaceManager.create_and_manage', mock.MagicMock(return_value=True))
+@mock.patch('reckoner.chart.NamespaceManager', NamespaceManagerMock)
 class TestChart(TestBase):
 
     @mock.patch('reckoner.course.get_helm_client', autospec=True)


### PR DESCRIPTION
Adding back chart fxn removed from #177 

Let's discuss what we want this to actually do. 

As it stands, the top level `namespace_managment.default` is completely overridden by the chart's `namespace_management` block. What do we want it to actually do?

