### PR TITLE
Add reset() classmethod to Config.

### DIFF
--- a/reckoner/config.py
+++ b/reckoner/config.py
@@ -39,6 +39,10 @@ class Config(object):
     """
     _config = {}
 
+    @classmethod
+    def reset(cls):
+        cls._config = {}
+
     def __init__(self):
         self.__dict__ = self._config
         self._installed_repositories = []
@@ -71,7 +75,10 @@ class Config(object):
 
     @property
     def course_base_directory(self):
-        return dirname(abspath(self.course_path))
+        if self.course_path:
+            return dirname(abspath(self.course_path))
+        else:
+            return '.'
 
     def __setattr__(self, name, value):
         object.__setattr__(self, name, value)

--- a/reckoner/tests/test_config.py
+++ b/reckoner/tests/test_config.py
@@ -18,6 +18,16 @@ from reckoner.config import Config
 
 
 class TestConfig(unittest.TestCase):
+    def setUp(self):
+        Config.reset()
+
+    def test_course_base_dir_doesnt_raise(self):
+        config = Config()
+        try:
+            config.course_base_directory
+        except TypeError as e:
+            self.fail(f"accessing course.course_base_directory of an empty Config() threw TypeError: {e}")
+
     @mock.patch('os.getcwd')
     def test_course_base_dir_never_empty(self, mock_dir):
         config = Config()

--- a/tests/test_reckoner.py
+++ b/tests/test_reckoner.py
@@ -41,6 +41,7 @@ class TestBase(unittest.TestCase):
         self.subprocess_mock_patch = mock.patch('subprocess.Popen')
         self.subprocess_mock = self.subprocess_mock_patch.start()
         self.m = mock.Mock()
+        Config.reset()
 
     def configure_subprocess_mock(self, stdout, stderr, returncode):
         attrs = {'returncode': returncode, 'communicate.return_value': (stdout, stderr)}


### PR DESCRIPTION
Reset `Config` between test runs.
Default to '.' as Config.course_base_directory when no course file is set.

Context:
Some amount of the current tests rely on side effects of other tests to pass. 
```shell
❯ pytest tests/test_reckoner.py::TestCourseMocks::test_passes_if_any_charts_exist
=============================================== test session starts ================================================
platform darwin -- Python 3.7.3, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /Users/hopson/src/fairwinds/reckoner
plugins: cov-2.7.1
collected 1 item

tests/test_reckoner.py F                                                                                     [100%]

===================================================== FAILURES =====================================================
_________________________________ TestCourseMocks.test_passes_if_any_charts_exist __________________________________

self = <tests.test_reckoner.TestCourseMocks testMethod=test_passes_if_any_charts_exist>
mock_helm = <function get_helm_client at 0x105530048>
mock_yaml = <MagicMock name='yaml_handler' spec='Handler' id='4384285640'>

    @mock.patch('reckoner.course.yaml_handler', autospec=True)
    @mock.patch('reckoner.course.get_helm_client', autospec=True)
    def test_passes_if_any_charts_exist(self, mock_helm, mock_yaml):
        course_yml = {
            'namespace': 'fake',
            'charts': {
                'fake-chart': {
                    'chart': 'none',
                    'version': 'none',
                    'repository': 'none',
                }
            }
        }

        mock_yaml.load.side_effect = [course_yml]
        # this is not okay I assume, I just added args
        helm_args = ['provided args']
        helm_instance = mock_helm(helm_args)
        helm_instance.client_version = '0.0.0'

>       instance = reckoner.course.Course(None)

tests/test_reckoner.py:125:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
reckoner/course.py:75: in __init__
    self._charts.append(Chart({name: chart}, self.helm))
reckoner/chart.py:99: in __init__
    self.config.course_base_directory
reckoner/config.py:74: in course_base_directory
    return dirname(abspath(self.course_path))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

path = None

    def abspath(path):
        """Return an absolute path."""
>       path = os.fspath(path)
E       TypeError: expected str, bytes or os.PathLike object, not NoneType

../../../.pyenv/versions/3.7.3/lib/python3.7/posixpath.py:378: TypeError
============================================= short test summary info ==============================================
FAILED tests/test_reckoner.py::TestCourseMocks::test_passes_if_any_charts_exist - TypeError: expected str, bytes ...
================================================ 1 failed in 0.71s =================================================
```

If the whole suite runs, this test passes because another test has set values in `reckoner.Config`

If `Config.course_base_directory` is unmodified but `Config.reset()` is added to `setUp()` in each test class, additional tests fail.  I think it makes sense to be able to initialize `reckoner.Chart` without a physical file, so I altered `Config.course_base_directory` to default to `.` 🤷‍♂ 