### PR TITLE
Use unittest.mock

### DIFF
--- a/development-requirements.txt
+++ b/development-requirements.txt
@@ -1,7 +1,6 @@
 pytest==5.4.1
 pytest-cov
 wheel
-mock
 autopep8
 flake8
 codecov

--- a/reckoner/helm/tests/test_client.py
+++ b/reckoner/helm/tests/test_client.py
@@ -16,8 +16,8 @@ from reckoner.helm.client import HelmClient, Helm2Client, Helm3Client, HelmClien
 from reckoner.helm.command import HelmCommand
 from reckoner.helm.cmd_response import HelmCmdResponse
 from reckoner.helm.provider import HelmProvider
-import mock
 import unittest
+from unittest import mock
 
 
 class TestHelm2Client(unittest.TestCase):

--- a/reckoner/helm/tests/test_provider.py
+++ b/reckoner/helm/tests/test_provider.py
@@ -14,7 +14,7 @@
 
 # Intent for this file is to be able to contract test ALL providers!
 import unittest
-import mock
+from unittest import mock
 from reckoner.helm.provider import HelmProvider
 from reckoner.helm.cmd_response import HelmCmdResponse
 from reckoner.helm.command import HelmCommand

--- a/reckoner/tests/test_chart.py
+++ b/reckoner/tests/test_chart.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 """Test the chart functions directly"""
-import mock
 import unittest
+from unittest import mock
 
 from io import StringIO
 

--- a/reckoner/tests/test_cli.py
+++ b/reckoner/tests/test_cli.py
@@ -15,7 +15,7 @@
 """Testing of CLI commands in click, contract tests"""
 
 import unittest
-import mock
+from unittest import mock
 from click.testing import CliRunner
 from reckoner import cli
 from reckoner.exception import ReckonerException

--- a/reckoner/tests/test_config.py
+++ b/reckoner/tests/test_config.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 import unittest
-import mock
+from unittest import mock
 from reckoner.config import Config
 
 
 class TestConfig(unittest.TestCase):
     @mock.patch('os.getcwd')
     def test_course_base_dir_never_empty(self, mock_dir):
+        mock_dir.return_value = "/some/fake/path"
         config = Config()
         config.course_path = 'course.yaml'
         self.assertNotEqual('', config.course_base_directory,
@@ -30,7 +31,6 @@ class TestConfig(unittest.TestCase):
         config.course_path = '/some/full/path/course.yml'
         self.assertEqual('/some/full/path', config.course_base_directory)
 
-        mock_dir.return_value = "/some/fake/path"
         config.course_path = './course.yaml'
         self.assertEqual('/some/fake/path', config.course_base_directory)
 

--- a/reckoner/tests/test_course.py
+++ b/reckoner/tests/test_course.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
 import unittest
+from unittest import mock
 from reckoner.hooks import Hook
 from reckoner.course import Course
 from reckoner.command_line_caller import Response

--- a/reckoner/tests/test_hooks.py
+++ b/reckoner/tests/test_hooks.py
@@ -1,5 +1,5 @@
-import mock
 import unittest
+from unittest import mock
 
 from reckoner.hooks import Hook
 from reckoner.command_line_caller import Response

--- a/reckoner/tests/test_kube.py
+++ b/reckoner/tests/test_kube.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
 import unittest
+from unittest import mock
 
 from reckoner.kube import NamespaceManager
 

--- a/reckoner/tests/test_reckoner.py
+++ b/reckoner/tests/test_reckoner.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-import mock
+from unittest import mock
 
 from reckoner.helm.client import HelmClientException
 from reckoner.reckoner import Reckoner, ReckonerInstallResults

--- a/tests/test_reckoner.py
+++ b/tests/test_reckoner.py
@@ -16,12 +16,12 @@
 
 
 import unittest
+from unittest import mock
 
 import coloredlogs
 import logging
 import os
 import shutil
-import mock
 import reckoner
 import ruamel.yaml as yaml
 


### PR DESCRIPTION
> mock is now part of the Python standard library, available as unittest.mock in Python 3.3 onwards.

`test_config` was the only required code change.