### PR TITLE
Enable chart level Namespace Manager

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,14 @@ charts:
     chart: nginx-ingress
     version: "0.25.1"
     namespace: nginx-ingress
+    namespace_management:
+      metadata:
+        annotations:
+          foo: bar
+        labels:
+          boo: far
+      settings:
+        overwrite: false
     repository: stable
     hooks:
       pre_install: echo hi

--- a/docs/README.md
+++ b/docs/README.md
@@ -166,6 +166,8 @@ minimum_versions:
 
 When you wish to manage annotations or labels for the namespaces you are installing into with Reckoner, this `namespace_management` block to define default namespace metadata and the whether or not it should overwrite the values that exist.
 
+`namespace_management` blocks can be defined at the top level or at the chart level. By default, the top level `default` metadata will be used for all namespaces and any `metadata.annotations` or `metadata.labels` set in the charts will be additive. However, if `settings.overwrite` is `True` then the `metadata` block from the chart will replace all overwrite any matching labels or annotations values.
+
 Example:
 ```yaml
 namespace_management:

--- a/docs/README.md
+++ b/docs/README.md
@@ -166,7 +166,9 @@ minimum_versions:
 
 When you wish to manage annotations or labels for the namespaces you are installing into with Reckoner, this `namespace_management` block to define default namespace metadata and the whether or not it should overwrite the values that exist.
 
-`namespace_management` blocks can be defined at the top level or at the chart level. By default, the top level `default` metadata will be used for all namespaces and any `metadata.annotations` or `metadata.labels` set in the charts will be additive. However, if `settings.overwrite` is `True` then the `metadata` block from the chart will replace all overwrite any matching labels or annotations values.
+`namespace_management` blocks can be defined at the top level or at the chart level. By default, the top level `default` metadata will be used for all namespaces and any `metadata.annotations` or `metadata.labels` set in the charts will be additive. However, if `settings.overwrite` is `True` then the `metadata` block from the chart will replace any matching labels or annotation values.
+
+Keep in mind, chart level `metadata` properties _cannot_ remove or delete any course level properties, only overwrite the value. For this reason, it's best if you don't set course level namespace metadata unless you truly want it applied to _all_ namespaces defined in this course.yml.
 
 Example:
 ```yaml

--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -109,7 +109,7 @@ class Chart(object):
         )
 
         self._namespace = self._chart.get('namespace')
-        self._namespace_management = None
+        self._namespace_management = self._chart.get('namespace_management')
         self._context = self._chart.get('context')
         value_strings = self._chart.get('values-strings', {})
         self._chart['values_strings'] = value_strings

--- a/reckoner/kube.py
+++ b/reckoner/kube.py
@@ -91,19 +91,23 @@ class NamespaceManager(object):
         """
         if self.overwrite:
             patch_metadata = self.metadata
-            logging.info("Overwriting Namespace Metadata")
+            logging.info("Overwriting Namespace '{}' Metadata".format(self.namespace_name))
         else:
             annotations = {}
             for annotation_name, annotation_value in self.metadata.get('annotations', {}).items():
                 try:
-                    self.namespace.metadata.annotations[annotation_name]
+                    current_annotation_value = self.namespace.metadata.annotations[annotation_name]
+                    if current_annotation_value != annotation_value:
+                        logging.info("Not Overwriting Metadata Annotation '{}' in Namespace '{}'".format(annotation_name,self.namespace_name))
                 except (TypeError, KeyError):
                     annotations[annotation_name] = annotation_value
 
             labels = {}
             for label_name, label_value in self.metadata.get('labels', {}).items():
                 try:
-                    self.namespace.metadata.labels[label_name]
+                    current_label_value = self.namespace.metadata.labels[label_name]
+                    if current_label_value != annotation_value:
+                        logging.info("Not Overwriting Metadata Label '{}' in Namespace '{}'".format(annotation_name,self.namespace_name))
                 except (TypeError, KeyError):
                     labels[label_name] = label_value
 

--- a/reckoner/kube.py
+++ b/reckoner/kube.py
@@ -91,7 +91,7 @@ class NamespaceManager(object):
         """
         if self.overwrite:
             patch_metadata = self.metadata
-            logging.debug("Overwriting Namespace Metadata")
+            logging.info("Overwriting Namespace Metadata")
         else:
             annotations = {}
             for annotation_name, annotation_value in self.metadata.get('annotations', {}).items():


### PR DESCRIPTION
The machinery was already in place, I switched it on, added a little more in the docs, and updated the log level for when chart level namespace manangment is set to overwrite