### PR TITLE
Add Helm Template

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -182,7 +182,9 @@ Options:
   --help            Show this message and exit.
 
 Commands:
-  plot     Install charts with given arguments as listed in yaml file...
+  plot     Install charts with given arguments as listed in yaml file argument
+  template Output the template of the chart or charts as they would be installed or
+  upgraded
   version  Takes no arguments, outputs version info
 ```
 
@@ -211,4 +213,26 @@ Options:
                                   does not already exist. Replaces
                                   functionality lost in Helm3
   --help                          Show this message and exit.
+```
+
+Or
+```text
+# reckoner template --help
+Usage: reckoner template [OPTIONS] COURSE_FILE
+
+  Output the template of the chart or charts as they would be installed or
+  upgraded
+
+Options:
+  -o, --only, --heading <chart>  Only run a specific chart by name  [required]
+  --helm-args TEXT               Passes the following arg on to helm, can be
+                                 used more than once. WARNING: Setting this
+                                 will completely override any helm_args in the
+                                 course. Also cannot be used for configuring
+                                 how helm connects to tiller.
+
+  --log-level TEXT               Log Level. [INFO | DEBUG | WARN | ERROR].
+                                 (default=INFO)
+
+  --help                         Show this message and exit.
 ```

--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -289,6 +289,17 @@ class Chart(object):
             if self._deprecation_messages:
                 [logging.warning(msg) for msg in self._deprecation_messages]
 
+    def template(self, default_namespace=None, default_namespace_management={}, context=None) -> None:
+        self.__pre_command(default_namespace, default_namespace_management, context)
+        try:
+            # Perform the template with the arguments
+            return self.helm.template(self.args, plugin=self.plugin)
+        except Exception as e:
+            logging.debug(traceback.format_exc)
+            raise e
+        finally:
+            self.clean_up_temp_files()
+
     def _append_arg(self, arg_string):
         for item in arg_string.split(" ", 1):
             self.args.append(item)

--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -234,10 +234,6 @@ class Chart(object):
             self._context = context
         # Try to run the install process for mark the result as failed
 
-        # TODO: Improve error handling of a repository installation
-        #       Thoughts here, perhaps it would be better to install the
-        #       repositories *before* trying to install the chart. This
-        #       way we could find out earlier our course is wrong.
         self.repository.install(self.name, self.version)
 
         # Update the helm dependencies
@@ -248,7 +244,6 @@ class Chart(object):
         self.build_helm_arguments_for_chart()
 
         # Check and Error if we're missing required env vars
-        # TODO Rename this function as it does more than just "check", it also interpolates
         self._check_env_vars()
 
     def install(self, default_namespace=None, default_namespace_management={}, context=None) -> None:

--- a/reckoner/cli.py
+++ b/reckoner/cli.py
@@ -86,6 +86,30 @@ def plot(ctx, course_file=None, dry_run=False, debug=False, only=None, helm_args
 
 
 @cli.command()
+@click.pass_context
+@click.argument('course_file', type=click.File('rb'))
+@click.option("--only", "--heading", "-o", "only", metavar="<chart>", help='Only run a specific chart by name', multiple=True, required=True)
+@click.option("--helm-args", help='Passes the following arg on to helm, can be used more than once. WARNING: Setting '
+                                  'this will completely override any helm_args in the course. Also cannot be used for '
+                                  'configuring how helm connects to tiller.', multiple=True)
+@click.option("--log-level", default="INFO", help="Log Level. [INFO | DEBUG | WARN | ERROR]. (default=INFO)")
+def template(ctx, only, log_level, course_file=None, helm_args=None,):
+    """Output the template of the chart or charts as they would be installed or upgraded"""
+    coloredlogs.install(level=log_level)
+    # Check Schema of Course FileA
+    with open(course_file.name, 'rb') as course_file_stream:
+        validate_course_file(course_file_stream)
+    # Load Reckoner
+    r = Reckoner(course_file=course_file, helm_args=helm_args)
+    # Convert tuple to list
+    only = list(only)
+    logging.debug(f'Only tempalating the following charts: {only}')
+    template_results = r.template(only)
+    for result in template_results:
+        print(result.stdout)
+
+
+@cli.command()
 def version():
     """ Takes no arguments, outputs version info"""
     print(__version__)

--- a/reckoner/cli.py
+++ b/reckoner/cli.py
@@ -53,8 +53,10 @@ def cli(ctx, log_level, *args, **kwargs):
               help="Attempt to install all charts in the course, even if any charts or hooks fail to run.")
 @click.option("--create-namespace/--no-create-namespace", default=True,
               help="Will create the specified nameaspace if it does not already exist. Replaces functionality lost in Helm3")
-def plot(ctx, course_file=None, dry_run=False, debug=False, only=None, helm_args=None, continue_on_error=False, create_namespace=True):
+@click.option("--log-level", default="INFO", help="Log Level. [INFO | DEBUG | WARN | ERROR]. (default=INFO)")
+def plot(ctx, log_level, course_file=None, dry_run=False, debug=False, only=None, helm_args=None, continue_on_error=False, create_namespace=True):
     """ Install charts with given arguments as listed in yaml file argument """
+    coloredlogs.install(level=log_level)
     try:
         # Check Schema of Course FileA
         with open(course_file.name, 'rb') as course_file_stream:

--- a/reckoner/course.py
+++ b/reckoner/course.py
@@ -256,8 +256,8 @@ class Course(object):
 
     def template(self, charts_requested_to_template: list) -> List[str]:
         """
-        Accepts charts_to_install, an interable of the names of the charts
-        to install. This method compares the charts in the argument to the
+        Accepts charts_requested_to_template, an iterable of the names of the charts
+        to template. This method compares the charts in the argument to the
         charts in the course and calls Chart.template()
 
         """
@@ -267,7 +267,7 @@ class Course(object):
 
     def plot(self, charts_requested_to_install: list) -> List[ChartResult]:
         """
-        Accepts charts_to_install, an interable of the names of the charts
+        Accepts charts_to_install, an iterable of the names of the charts
         to install. This method compares the charts in the argument to the
         charts in the course and calls Chart.install()
 

--- a/reckoner/course.py
+++ b/reckoner/course.py
@@ -224,7 +224,7 @@ class Course(object):
         return the intersection. Will log if chart is requested but not
         present in the chart
         """
-        _only_charts = []
+        self._only_charts = []
 
         # NOTE: Unexpected feature here: Since we're iterating on all charts
         #       in the course to find the ones the user has requested, a
@@ -234,7 +234,7 @@ class Course(object):
 
         for chart in self.charts:
             if chart.release_name in charts_requested:
-                _only_charts.append(chart)
+                self._only_charts.append(chart)
                 charts_requested.remove(chart.release_name)
             else:
                 logging.debug(
@@ -245,14 +245,14 @@ class Course(object):
         # If any items remain in charts requested - warn that we didn't find them
         self._warn_about_missing_requested_charts(charts_requested)
 
-        if len(_only_charts) == 0:
+        if len(self._only_charts) == 0:
             raise NoChartsToInstall(
                 'None of the charts you requested ({}) could be '
                 'found in the course list. Verify you are using the '
                 'release-name and not the chart name.'.format(', '.join(charts_requested))
             )
 
-        return _only_charts
+        return self._only_charts
 
     def template(self, charts_requested_to_template: list) -> List[str]:
         """

--- a/reckoner/helm/client.py
+++ b/reckoner/helm/client.py
@@ -155,6 +155,9 @@ class HelmClient(ABC):
             arguments = args
         return self.execute("upgrade", arguments, plugin=plugin)
 
+    def template(self, args, plugin=None):
+        return self.execute("template", args, plugin=plugin)
+
     def rollback(self, release):
         raise NotImplementedError(
             """This is known bad. If you see this error then you are likely implementing the solution :)"""

--- a/reckoner/reckoner.py
+++ b/reckoner/reckoner.py
@@ -106,6 +106,19 @@ class Reckoner(object):
             logging.error(error)
             raise ReckonerCommandException('Failed to find any valid charts to install.')
 
+    def template(self, charts: List[str] = [] ):
+        selected_charts = charts or [chart._release_name for chart in self.course.charts]
+        try:
+            return self.course.template(selected_charts)
+            # for chart_result in plot_results:
+            #     if chart_result:
+            #         self.add_result(chart_result)
+            #     else:
+            #         raise Exception("Didn't expect None as a chart result...")
+        except NoChartsToInstall as error:
+            logging.error(error)
+            raise ReckonerCommandException('Failed to find any valid charts to install.')
+
     def add_result(self, result: ChartResult) -> None:
         self.results.add_result(result)
 

--- a/reckoner/reckoner.py
+++ b/reckoner/reckoner.py
@@ -110,11 +110,6 @@ class Reckoner(object):
         selected_charts = charts or [chart._release_name for chart in self.course.charts]
         try:
             return self.course.template(selected_charts)
-            # for chart_result in plot_results:
-            #     if chart_result:
-            #         self.add_result(chart_result)
-            #     else:
-            #         raise Exception("Didn't expect None as a chart result...")
         except NoChartsToInstall as error:
             logging.error(error)
             raise ReckonerCommandException('Failed to find any valid charts to install.')

--- a/tests/test_reckoner.py
+++ b/tests/test_reckoner.py
@@ -296,7 +296,7 @@ class TestCourse(TestBase):
     def test_plot_course(self):
         self.configure_subprocess_mock('', '', 0)  # TODO: Lots of work do do here on installation of the list of charts
         self.c.plot(list(self.c._dict['charts']))
-        self.assertEqual(self.c._charts_to_install, self.c.charts)
+        self.assertEqual(self.c._only_charts, self.c.charts)
 
 
 @mock.patch('reckoner.chart.NamespaceManager', NamespaceManagerMock)


### PR DESCRIPTION
This PR adds the `template` command through Reckoner. Since a lot of the machinery needed for `plot` was reusable, there was a fair amount of refactoring to keep things dry-er. Template itself just `print`s the tempalte output to stdout instead of logging because logging in python goes to STDERR. This means you can `reckoner template -o <chart> course.yml > manifests.yml` and you'll get a file with yaml and still see all the logs. 

I elected to make `-o` required thinking that one probably does not want to template out the entire reckoner file but I'm on the fence about it. Happy to hear feedback.