### PR TITLE
MAJOR (potentially breaking)  Add --run-all. Make either run-all or only required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ charts:
 Then run:
 
 ```shell
-reckoner plot course.yaml
+reckoner plot course.yaml --run-all
 ```
 
 Grafana and Polaris should now be installed on your cluster!

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,24 +6,24 @@ The "course" is the definition of charts you wish to install using Reckoner. It 
 We'll be breaking this documentation down into sections to make reference easier. We'll be starting by looking at top level definitions in your course YAML and breaking down into the lower level objects that make up the course. Keys will be denoted as required, otherwise they are optional.
 
 # Top Level Keys
-- `namespace` _(string)_ _**(required)**_  
+- `namespace` _(string)_ _**(required)**_
     The default namespace for any chart definitions in your course
 - `namespace_management` _(object)_ **(optional)** a structure the defines default annotations and labels to the namespaces that Reckoner will create
-- `charts` _(object)_ _**(required)**_  
+- `charts` _(object)_ _**(required)**_
     The charts and chart definitions to install with this course, must be alphanumeric between 1 and 63 characters (also allows underscore and dash)
-- `hooks` _(object)_  
+- `hooks` _(object)_
     Allows `pre_install` and `post_install` which can be a string or a list of strings to execute in the shell around your chart installation (execution working directory is relative to your course file)
-- `repositories` _(object)_  
+- `repositories` _(object)_
     The definition of remote chart repositories available to this course
-- `minimum_versions` _(object)_  
+- `minimum_versions` _(object)_
     The minimum helm and reckoner versions required to run this course
-- `repository` _(string)_  
+- `repository` _(string)_
     The default remote repository for charts in this course if one is not defined in the chart definition
-- `context` _(string)_  
+- `context` _(string)_
     The `kubectl` context to use for this course (found with `kubectl config current-context`)
-- `_references` _(object)_  
+- `_references` _(object)_
     An area in which you can put repeat code to be used throughout your course YAML. (See [this article on anchors](https://medium.com/@kinghuang/docker-compose-anchors-aliases-extensions-a1e4105d70bd))
-- `helm_args` _(string)_  
+- `helm_args` _(string)_
     The default helm arguments to provide to any helm command run by Reckoner in this course
 
 Example:
@@ -56,26 +56,26 @@ charts:
 ## Charts
 The `charts` block in your course define all the charts you'd like to install and the values that the chart should be installed with. The `key` of your chart definition is the name (`release-name`) that Reckoner will ask helm to install under. Release names only allow alphanumerics, underscores and dashes and must be between 1 and 63 characters long.
 
-- `namespace` _(string)_  
+- `namespace` _(string)_
     The namespace in which to install this chart (overrides root level `namespace` definition)
 - `namespace_management` _(object)_ **(optional)** a structure the defines default annotations and labels to the namespace that Reckoner will create. Structure matches the `default` structure at the top level `namespace_management` block.
-- `chart` _(string)_  
+- `chart` _(string)_
     The name of the chart in the remote chart respository (example: `nginx-ingress`) and when using git repositories this is the folder in which the chart files exist
-- `repository` _(string)_ or _(object)_  
+- `repository` _(string)_ or _(object)_
     The name of the remote chart repository defined in the root level of your course (example: `stable`) and also can be passed a repository definition (like in the root key `repositories`)
-- `version` _(string)_  
+- `version` _(string)_
     The version of the chart in the remote chart repository (NOTE: When using a git repository, this is translated into the `ref` in the git repository, either commit SHA or tag name)
-- `hooks` _(object)_  
+- `hooks` _(object)_
     Allows `pre_install` and `post_install` which can be a string or a list of strings to execute in the shell around your chart installation (execution working directory is relative to your course file)
-- `files` _(list of strings)_  
+- `files` _(list of strings)_
     Translates into `-f filename` for the helm install command line arguments (files are pathed relative to your course file)
-- `values` _(object)_  
+- `values` _(object)_
     Translates into a direct YAML values file for use with `-f <tmpfile>` for the helm install command line arguments
-- `set-values` _(object)_  
+- `set-values` _(object)_
     Translates all key-values into `--set` values for the helm install command line arguments
-- `values-strings` _(object)_  
+- `values-strings` _(object)_
     Translates all key-values into `--set-string` values for the helm install command line arguments
-- `plugins` _(string)_  
+- `plugins` _(string)_
     Prepend your helm commands with this `plugins` string (see [PR 99](https://github.com/FairwindsOps/reckoner/pull/99))
 
 ```yaml
@@ -112,13 +112,13 @@ charts:
 This block defines all the remote chart repositories available for use in this course file. This definition can be used in the root level `repositories` block, or in the chart level `repository` block definition. NOTE: It cannot be used in the root level `repository` definition.
 
 Keys:
-- `url` _(string)_  
+- `url` _(string)_
     The URL of the http chart repository
-- `git` _(string)_  
+- `git` _(string)_
     The git endpoint from which to pull the chart, in SSH or HTTP form (i.e. `git@github.com:FairwindsOps/charts.git`)
-- `path` _(string)_ _**git specific**_  
+- `path` _(string)_ _**git specific**_
     The path in the remote git chart repository in which to find the chart (i.e. `stable`)
-- `name` _(string)_  
+- `name` _(string)_
     The name to use for this remote chart repository in `helm repo list`, if not defined then the key of the definition is used
 
 Repositories definitions support both HTTP and GIT endpoints for pulling charts. Below are the two supported schemas for each implementation.
@@ -150,7 +150,7 @@ charts:
 ```
 
 ## Minimum Versions
-- `reckoner` _(string)_  
+- `reckoner` _(string)_
     The minimum version of reckoner for this course to work properly (in semver notation).
 - `helm` _(string)_
     The desired version of helm to run this course with (will fail if `helm` in your path is older than the version specified).
@@ -210,20 +210,35 @@ Usage: reckoner plot [OPTIONS] COURSE_FILE
 Options:
   --dry-run                       Pass --dry-run to helm so no action is
                                   taken. Implies --debug and skips hooks.
-  --debug                         DEPRECATED - use --dry-run instead, or pass
-                                  to --helm-args
-  -o, --only, --heading <chart>   Only run a specific chart by name
+
+  --debug                         DEPRECATED - use --log-level=DEBUG as a
+                                  parameter to `reckoner` instead. May be used
+                                  with or without `--dry-run`. Or, pass
+                                  `--debug` to --helm-args
+
+  -a, --run-all                   Run all charts in the course. Mutually
+                                  exclusive with 'only'.
+
+  -o, --only, --heading <chart>   Only run a specific chart by name Mutually
+                                  exclusive with 'run_all'.
+
   --helm-args TEXT                Passes the following arg on to helm, can be
                                   used more than once. WARNING: Setting this
                                   will completely override any helm_args in
                                   the course. Also cannot be used for
                                   configuring how helm connects to tiller.
+
   --continue-on-error             Attempt to install all charts in the course,
                                   even if any charts or hooks fail to run.
+
   --create-namespace / --no-create-namespace
                                   Will create the specified nameaspace if it
                                   does not already exist. Replaces
                                   functionality lost in Helm3
+
+  --log-level TEXT                Log Level. [INFO | DEBUG | WARN | ERROR].
+                                  (default=INFO)
+
   --help                          Show this message and exit.
 ```
 
@@ -236,7 +251,12 @@ Usage: reckoner template [OPTIONS] COURSE_FILE
   upgraded
 
 Options:
-  -o, --only, --heading <chart>  Only run a specific chart by name  [required]
+  -a, --run-all                  Run all charts in the course. Mutually
+                                 exclusive with 'only'.
+
+  -o, --only, --heading <chart>  Only run a specific chart by name. Mutually
+                                 exclusive with 'run_all'.
+
   --helm-args TEXT               Passes the following arg on to helm, can be
                                  used more than once. WARNING: Setting this
                                  will completely override any helm_args in the

--- a/end_to_end_testing/run_end_to_end.sh
+++ b/end_to_end_testing/run_end_to_end.sh
@@ -112,7 +112,7 @@ function namespace_has_annotation_with_value() {
     annotations=($(kubectl get namespace ${namespace}  -o json | jq -r '.metadata.annotations | keys[]'))
     values=($(kubectl get namespace ${namespace}  -o json | jq -r '.metadata.annotations[]'))
 
-    for i in "${!annotations[@]}"; do 
+    for i in "${!annotations[@]}"; do
         if [ "${annotations[i]}" == "$annotation_name" ]; then
             if [ "${values[i]}" == "$annotation_value" ]; then
                 return 0
@@ -131,7 +131,7 @@ function namespace_has_label_with_value() {
     labels=($(kubectl get namespace ${namespace}  -o json | jq -r '.metadata.labels | keys[]'))
     values=($(kubectl get namespace ${namespace}  -o json | jq -r '.metadata.labels[]'))
 
-    for i in "${!labels[@]}"; do 
+    for i in "${!labels[@]}"; do
         if [ "${labels[i]}" == "$label_name" ]; then
             if [ "${values[i]}" == "$label_value" ]; then
                 return 0
@@ -150,7 +150,7 @@ function helm_get_values(){
 
     if [ "${HELM_VERSION}" -eq "3" ]; then
         namespace=$(release_namespace ${1})
-        helm get values --output=json --namespace "${namespace}" "${1}" 
+        helm get values --output=json --namespace "${namespace}" "${1}"
     else
         helm get values --output=json "${1}"
     fi
@@ -193,7 +193,7 @@ function helm_release_key_value_is_type() {
 
 function e2e_test_namespace_creation_flag_on_chart_install() {
     if [ "${HELM_VERSION}" -eq "3" ]; then
-        if reckoner plot --no-create-namespace test_create_namespace.yml; then
+        if reckoner plot --no-create-namespace test_create_namespace.yml --run-all; then
             mark_failed "${FUNCNAME[0]}" "With --no-create-namespace set, this should have failed"
         fi
 
@@ -201,7 +201,7 @@ function e2e_test_namespace_creation_flag_on_chart_install() {
             mark_failed "${FUNCNAME[0]}" "Found namespace_test in farglebargle namespace after install and should not have"
         fi
 
-        if ! reckoner plot test_create_namespace.yml; then
+        if ! reckoner plot test_create_namespace.yml --run-all; then
             mark_failed "${FUNCNAME[0]}" "Without --no-create-namespace set, this should not have failed"
         fi
 
@@ -210,11 +210,11 @@ function e2e_test_namespace_creation_flag_on_chart_install() {
         fi
     fi
 
- 
+
 }
 
 function e2e_test_basic_chart_install() {
-    if ! reckoner plot test_basic.yml; then
+    if ! reckoner plot test_basic.yml --run-all; then
         mark_failed "${FUNCNAME[0]}" "Plot had a bad exit code"
     fi
 
@@ -224,7 +224,7 @@ function e2e_test_basic_chart_install() {
 }
 
 function e2e_test_env_var() {
-    if ! myvar=testing reckoner plot test_env_var.yml; then
+    if ! myvar=testing reckoner plot test_env_var.yml --run-all; then
         mark_failed "${FUNCNAME[0]}" "Could not install course"
     fi
 
@@ -242,13 +242,13 @@ function e2e_test_env_var() {
 }
 
 function e2e_test_env_var_exit_code() {
-    if reckoner plot test_env_var.yml; then
+    if reckoner plot test_env_var.yml --run-all; then
         mark_failed "${FUNCNAME[0]}" "Should fail to plot course without env var."
     fi
 }
 
 function e2e_test_good_hooks() {
-    if ! reckoner plot test_good_hooks.yml; then
+    if ! reckoner plot test_good_hooks.yml --run-all; then
         mark_failed "${FUNCNAME[0]}" "Plot had bad exit code"
     fi
 
@@ -257,7 +257,7 @@ function e2e_test_good_hooks() {
 
 function e2e_test_exit_on_post_install_hook() {
     # we expect this to fail exit code != 0
-    if reckoner plot test_exit_on_post_install_hook.yml; then
+    if reckoner plot test_exit_on_post_install_hook.yml --run-all; then
         mark_failed "${FUNCNAME[0]}" "Expected plot to have a bad exit code"
     fi
 
@@ -268,7 +268,7 @@ function e2e_test_exit_on_post_install_hook() {
 
 function e2e_test_exit_on_pre_install_hook() {
     # we expect this to fail exit code != 0
-    if reckoner plot test_exit_on_pre_install_hook.yml; then
+    if reckoner plot test_exit_on_pre_install_hook.yml --run-all; then
         mark_failed "${FUNCNAME[0]}" "Expected plot to have a bad exit code"
     fi
 
@@ -280,7 +280,7 @@ function e2e_test_exit_on_pre_install_hook() {
 
 function e2e_test_failed_chart() {
     # we expect this command to have a bad exit code
-    if reckoner plot test_failed_chart.yml; then
+    if reckoner plot test_failed_chart.yml --run-all; then
         mark_failed "${FUNCNAME[0]}" "Expected plot to fail with bad exit code"
     fi
 
@@ -290,7 +290,7 @@ function e2e_test_failed_chart() {
 }
 
 function e2e_test_multi_chart() {
-    if ! reckoner plot test_multi_chart.yml; then
+    if ! reckoner plot test_multi_chart.yml --run-all; then
         mark_failed "${FUNCNAME[0]}" "Expected plot to succeed"
     fi
 
@@ -304,14 +304,14 @@ function e2e_test_multi_chart() {
 }
 
 function e2e_test_install_only_one_chart() {
-    if ! reckoner plot --only first-chart test_multi_chart.yml; then
+    if ! reckoner plot --only first-chart test_multi_chart.yml --run-all; then
         mark_failed "${FUNCNAME[0]}" "Expected plot command with --only to pass"
     fi
 
     if ! helm_has_release_name_in_namespace "first-chart" "infra"; then
         mark_failed "${FUNCNAME[0]}" "Expected plot to install first-chart"
     fi
-    
+
     # we do not expect second-chart due to --only
     if helm_has_release_name_in_namespace "second-chart" "test"; then
         mark_failed "${FUNCNAME[0]}" "Expected second-chart to be ignored due to --only flag"
@@ -319,7 +319,7 @@ function e2e_test_install_only_one_chart() {
 }
 
 function e2e_test_git_chart() {
-    if ! reckoner plot test_git_chart.yml; then
+    if ! reckoner plot test_git_chart.yml --run-all; then
         mark_failed "${FUNCNAME[0]}" "Expected chart plot to succeed"
     fi
 
@@ -341,13 +341,13 @@ function e2e_test_git_chart() {
     else
         helm delete --purge go-harbor
     fi
-    
+
     kubectl delete pvc --all-namespaces --all
 }
 
 function e2e_test_stop_after_first_failure() {
     # we expect a non-zero exit code here
-    if reckoner plot test_stop_after_first_failure.yml; then
+    if reckoner plot test_stop_after_first_failure.yml --run-all; then
         mark_failed "${FUNCNAME[0]}" "Expected reckoner to exit with a bad exit code."
     fi
 
@@ -366,7 +366,7 @@ function e2e_test_stop_after_first_failure() {
 
 function e2e_test_continue_after_first_failure() {
     # we expect a non-zero exit code here
-    if reckoner plot --continue-on-error test_continue_after_first_failure.yml; then
+    if reckoner plot --continue-on-error test_continue_after_first_failure.yml --run-all; then
         mark_failed "${FUNCNAME[0]}" "Expected reckoner to exit with a bad exit code."
     fi
 
@@ -400,10 +400,10 @@ function e2e_test_strong_ordering() {
     # Custom check which subtracts the two modified timestamps
     # This will fail if they are modified at the same second...
     local first_chart_timestamp
-    
+
     local second_chart_timestamp
-    
-    
+
+
     if [ "${HELM_VERSION}" -eq "3" ]; then
         first_chart_timestamp="$(helm ls --namespace test -a --output json | jq '.[] |select(.name == "first-chart") | .updated' -r | awk -F"." '{ print $1 }' | tr -d \\n | xargs -I {} date -d {} +%s)"
         second_chart_timestamp="$(helm ls --namespace test -a --output json | jq '.[] |select(.name == "second-chart") | .updated' -r | awk -F"." '{ print $1 }' | tr -d \\n | xargs -I {} date -d {} +%s)"
@@ -418,7 +418,7 @@ function e2e_test_strong_ordering() {
 }
 
 function e2e_test_strong_typing() {
-    if ! yes_var=yes true_var=true false_var=false int_var=123 float_var=1.234 reckoner plot test_strong_typing.yml; then
+    if ! yes_var=yes true_var=true false_var=false int_var=123 float_var=1.234 reckoner plot test_strong_typing.yml --run-all; then
         mark_failed "${FUNCNAME[0]}" "Expected the course to be installable."
     fi
 
@@ -428,7 +428,7 @@ function e2e_test_strong_typing() {
     else
         charts="$(helm ls --output json | jq -e -r '.Releases[].Name')"
     fi
-    
+
     for _release_install in ${charts}; do
         # Check if the chart is installed
         if ! helm_has_release_name_in_namespace "${_release_install}" "testing"; then
@@ -438,7 +438,7 @@ function e2e_test_strong_typing() {
 
         # Check that all charts have these keys
         local values
-        
+
         if [ "${HELM_VERSION}" -eq "3" ]; then
             values="$(helm get values --namespace testing "${_release_install}" --output json | jq -e -r 'keys|.[]')"
         else
@@ -484,19 +484,19 @@ function e2e_test_strong_typing() {
 }
 
 function e2e_test_bad_schema_repository() {
-    if reckoner plot test_bad_schema_repository.yml; then
+    if reckoner plot test_bad_schema_repository.yml --run-all; then
         mark_failed "${FUNCNAME[0]}" "Expected to fail on schema validation failure."
     fi
 }
 
 function e2e_test_required_schema() {
-    if reckoner plot test_required_schema.yml; then
+    if reckoner plot test_required_schema.yml --run-all; then
         mark_failed "${FUNCNAME[0]}" "Expected to fail on schema validation failure."
     fi
 }
 
 function e2e_test_files_in_folders() {
-    if ! reckoner plot testing_in_folder/test_files_in_folders.yml; then
+    if ! reckoner plot testing_in_folder/test_files_in_folders.yml --run-all; then
         mark_failed "${FUNCNAME[0]}" "Expected to run without an error."
     fi
 
@@ -506,7 +506,7 @@ function e2e_test_files_in_folders() {
 }
 
 function e2e_test_default_namespace_management(){
-    if ! reckoner plot test_default_namespace_annotation_and_labels.yml; then
+    if ! reckoner plot test_default_namespace_annotation_and_labels.yml --run-all; then
         mark_failed "${FUNCNAME[0]}" "Expected to run without an error."
     fi
 
@@ -520,7 +520,7 @@ function e2e_test_default_namespace_management(){
 }
 
 function e2e_test_overwrite_namespace_management(){
-    if ! reckoner plot test_overwrite_namespace_annotation_and_labels.yml; then
+    if ! reckoner plot test_overwrite_namespace_annotation_and_labels.yml --run-all; then
         mark_failed "${FUNCNAME[0]}" "Expected to run without an error."
     fi
 
@@ -534,7 +534,7 @@ function e2e_test_overwrite_namespace_management(){
 }
 
 function e2e_test_does_not_overwrite_namespace_management(){
-    if ! reckoner plot test_overwrite_namespace_annotation_and_labels.yml; then
+    if ! reckoner plot test_overwrite_namespace_annotation_and_labels.yml --run-all; then
         mark_failed "${FUNCNAME[0]}" "Expected to run without an error."
     fi
 

--- a/end_to_end_testing/run_end_to_end.sh
+++ b/end_to_end_testing/run_end_to_end.sh
@@ -304,7 +304,7 @@ function e2e_test_multi_chart() {
 }
 
 function e2e_test_install_only_one_chart() {
-    if ! reckoner plot --only first-chart test_multi_chart.yml --run-all; then
+    if ! reckoner plot --only first-chart test_multi_chart.yml; then
         mark_failed "${FUNCNAME[0]}" "Expected plot command with --only to pass"
     fi
 

--- a/reckoner/cli.py
+++ b/reckoner/cli.py
@@ -135,7 +135,7 @@ def template(ctx, only, run_all, log_level, course_file=None, helm_args=None):
         validate_course_file(course_file_stream)
     # Load Reckoner
     r = Reckoner(course_file=course_file, helm_args=helm_args)
-    # Convert tuple to list    
+    # Convert tuple to list
     only = list(only)
     logging.debug(f'Only tempalating the following charts: {only}')
     template_results = r.template(only)


### PR DESCRIPTION
Makes either --run-all or --only required. Running `reckoner plot course.yml` with no arguments will now produce an error.

This applies to both the `plot` and `template` commands

```
  -a, --run-all                   Run all charts in the course. Mutually
                                  exclusive with 'only'.

  -o, --only, --heading <chart>   Only run a specific chart by name Mutually
                                  exclusive with 'run_all'.
```

```
└─ reckoner plot course.yaml -o foo -a
Error: Illegal usage: 'only' is mutually exclusive with 'run_all'.
```

Fixes #186 