### PR TITLE
Adding Diff command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -199,7 +199,7 @@ Commands:
   upgraded
   get-manifests  Output the manifests of the chart or charts as they are installed
   diff           Output diff of the templates that would be installed and the manifests as they are installed
-  update         Checks to see if any thing will have changed, if so, updated the release, if not, does nothing
+  update         Checks to see if anything will be changed, if so, update the release, if not, does nothing
   version  Takes no arguments, outputs version info
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -194,9 +194,12 @@ Options:
   --help            Show this message and exit.
 
 Commands:
-  plot     Install charts with given arguments as listed in yaml file argument
-  template Output the template of the chart or charts as they would be installed or
+  plot           Install charts with given arguments as listed in yaml file argument
+  template       Output the template of the chart or charts as they would be installed or
   upgraded
+  get-manifests  Output the manifests of the chart or charts as they are installed
+  diff           Output diff of the templates that would be installed and the manifests as they are installed
+  update         Checks to see if any thing will have changed, if so, updated the release, if not, does nothing
   version  Takes no arguments, outputs version info
 ```
 
@@ -206,6 +209,49 @@ $> reckoner plot --help
 Usage: reckoner plot [OPTIONS] COURSE_FILE
 
   Install charts with given arguments as listed in yaml file argument
+
+Options:
+  --dry-run                       Pass --dry-run to helm so no action is
+                                  taken. Implies --debug and skips hooks.
+
+  --debug                         DEPRECATED - use --log-level=DEBUG as a
+                                  parameter to `reckoner` instead. May be used
+                                  with or without `--dry-run`. Or, pass
+                                  `--debug` to --helm-args
+
+  -a, --run-all                   Run all charts in the course. Mutually
+                                  exclusive with 'only'.
+
+  -o, --only, --heading <chart>   Only run a specific chart by name Mutually
+                                  exclusive with 'run_all'.
+
+  --helm-args TEXT                Passes the following arg on to helm, can be
+                                  used more than once. WARNING: Setting this
+                                  will completely override any helm_args in
+                                  the course. Also cannot be used for
+                                  configuring how helm connects to tiller.
+
+  --continue-on-error             Attempt to install all charts in the course,
+                                  even if any charts or hooks fail to run.
+
+  --create-namespace / --no-create-namespace
+                                  Will create the specified nameaspace if it
+                                  does not already exist. Replaces
+                                  functionality lost in Helm3
+
+  --log-level TEXT                Log Level. [INFO | DEBUG | WARN | ERROR].
+                                  (default=INFO)
+
+  --help                          Show this message and exit.
+```
+
+Or
+```
+# reckoner update --help
+Usage: reckoner update [OPTIONS] COURSE_FILE
+
+  Checks to see if any thing will have changed, if so, updated the release,
+  if not, does nothing
 
 Options:
   --dry-run                       Pass --dry-run to helm so no action is

--- a/docs/README.md
+++ b/docs/README.md
@@ -250,7 +250,7 @@ Or
 # reckoner update --help
 Usage: reckoner update [OPTIONS] COURSE_FILE
 
-  Checks to see if any thing will have changed, if so, updated the release,
+  Checks to see if anything will be changed, if so, update the release,
   if not, does nothing
 
 Options:

--- a/end_to_end_testing/run_end_to_end.sh
+++ b/end_to_end_testing/run_end_to_end.sh
@@ -573,6 +573,33 @@ function e2e_test_get_manifests_non_existent() {
     fi
 }
 
+function e2e_test_get_diff() {
+    if [ "${HELM_VERSION}" -eq "3" ]; then
+        reckoner plot test_basic.yml --run-all
+        if ! reckoner get-manifests test_basic.yml -o first-chart; then
+            mark_failed "${FUNCNAME[0]}" "Expected to succeed getting diff of release"
+        fi
+    fi
+}
+
+function e2e_test_get_update_of_release() {
+    if [ "${HELM_VERSION}" -eq "3" ]; then
+        reckoner plot test_basic.yml --run-all
+        if ! reckoner update test_basic.yml -o first-chart; then
+            mark_failed "${FUNCNAME[0]}" "Expected to succeed updating release"
+        fi
+    fi
+}
+
+function e2e_test_get_update_of_run_all() {
+    if [ "${HELM_VERSION}" -eq "3" ]; then
+        reckoner plot test_basic.yml --run-all
+        if ! reckoner update test_basic.yml --run-all; then
+            mark_failed "${FUNCNAME[0]}" "Expected to succeed updating all"
+        fi
+    fi
+}
+
 function run_test() {
     local test_name
     test_name="${1}"

--- a/reckoner/cli.py
+++ b/reckoner/cli.py
@@ -27,7 +27,7 @@ from .config import Config
 
 from reckoner.schema_validator.course import validate_course_file
 
-update_repos_option = click.option("--update-repos/--no-update-repos", default=False,
+update_repos_option = click.option("--update-repos/--no-update-repos", default=True,
                                    help="Will update Helm repos when --update-repos is specified [DEFAULT]. Skips update when --no-update-repos is specified.")
 
 

--- a/reckoner/cli.py
+++ b/reckoner/cli.py
@@ -23,8 +23,12 @@ import coloredlogs
 from . import exception
 from .meta import __version__
 from .reckoner import Reckoner
+from .config import Config
 
 from reckoner.schema_validator.course import validate_course_file
+
+update_repos_option = click.option("--update-repos/--no-update-repos", default=False,
+                                   help="Will update Helm repos when --update-repos is specified [DEFAULT]. Skips update when --no-update-repos is specified.")
 
 
 class Mutex(click.Option):
@@ -75,9 +79,11 @@ def cli(ctx, log_level, *args, **kwargs):
 @click.option("--create-namespace/--no-create-namespace", default=True,
               help="Will create the specified nameaspace if it does not already exist. Replaces functionality lost in Helm3")
 @click.option("--log-level", default="INFO", help="Log Level. [INFO | DEBUG | WARN | ERROR]. (default=INFO)")
-def plot(ctx, run_all, log_level, course_file=None, dry_run=False, debug=False, only=None, helm_args=None, continue_on_error=False, create_namespace=True):
+@update_repos_option
+def plot(ctx, run_all, log_level, course_file=None, dry_run=False, debug=False, only=None, helm_args=None, continue_on_error=False, create_namespace=True, update_repos=True):
     """ Install charts with given arguments as listed in yaml file argument """
     coloredlogs.install(level=log_level)
+    Config().update_repos = update_repos
     if not run_all:
         if len(only) < 1:
             logging.error("You must pass either --run-all or --only.")
@@ -184,7 +190,8 @@ def get_manifests(ctx, only, run_all, log_level, course_file=None, helm_args=Non
                                   'this will completely override any helm_args in the course. Also cannot be used for '
                                   'configuring how helm connects to tiller.', multiple=True)
 @click.option("--log-level", default="INFO", help="Log Level. [INFO | DEBUG | WARN | ERROR]. (default=INFO)")
-def diff(ctx, only, run_all, log_level, course_file=None, helm_args=None):
+@update_repos_option
+def diff(ctx, only, run_all, log_level, course_file=None, helm_args=None, update_repos=True):
     """Output diff of the templates that would be installed and the manifests that are currently installed"""
 
     coloredlogs.install(level=log_level)
@@ -192,9 +199,13 @@ def diff(ctx, only, run_all, log_level, course_file=None, helm_args=None):
         if len(only) < 1:
             logging.error("You must pass either --run-all or --only.")
             ctx.exit(1)
+
+    Config().update_repos = update_repos
+
     # Check Schema of Course FileA
     with open(course_file.name, 'rb') as course_file_stream:
         validate_course_file(course_file_stream)
+
     # Load Reckoner
     r = Reckoner(course_file=course_file, helm_args=helm_args)
     # Convert tuple to list
@@ -204,11 +215,12 @@ def diff(ctx, only, run_all, log_level, course_file=None, helm_args=None):
     for result in diff_results:
         print(result.response)
 
+
 @cli.command()
 @click.pass_context
 @click.argument('course_file', type=click.File('rb'))
 @click.option("--dry-run", is_flag=True, help='Pass --dry-run to helm so no action is taken. Implies --debug and '
-                                              'skips hooks.')
+              'skips hooks.')
 @click.option("--debug", is_flag=True, help='DEPRECATED - use --log-level=DEBUG as a parameter to `reckoner` instead. May be used with or without `--dry-run`. Or, pass `--debug` to --helm-args')
 @click.option("--run-all", "-a", "run_all", is_flag=True, help='Run all charts in the course.', cls=Mutex, not_required_if=["only"])
 @click.option("--only", "--heading", "-o", "only", metavar="<chart>", help='Only run a specific chart by name', multiple=True, cls=Mutex,
@@ -221,9 +233,11 @@ def diff(ctx, only, run_all, log_level, course_file=None, helm_args=None):
 @click.option("--create-namespace/--no-create-namespace", default=True,
               help="Will create the specified nameaspace if it does not already exist. Replaces functionality lost in Helm3")
 @click.option("--log-level", default="INFO", help="Log Level. [INFO | DEBUG | WARN | ERROR]. (default=INFO)")
-def update(ctx, run_all, log_level, course_file=None, dry_run=False, debug=False, only=None, helm_args=None, continue_on_error=False, create_namespace=True):
+@update_repos_option
+def update(ctx, run_all, log_level, course_file=None, dry_run=False, debug=False, only=None, helm_args=None, continue_on_error=False, create_namespace=True, update_repos=True):
     """Checks to see if any thing will have changed, if so, updated the release, if not, does nothing"""
     coloredlogs.install(level=log_level)
+    Config().update_repos = update_repos
     if not run_all:
         if len(only) < 1:
             logging.error("You must pass either --run-all or --only.")

--- a/reckoner/config.py
+++ b/reckoner/config.py
@@ -55,6 +55,17 @@ class Config(object):
         else:
             return '.'
 
+    @property
+    def update_repos(self):
+        if self.__dict__.get('update_repos') is not None:
+            return self.__dict__.get('update_repos')
+        else:
+            return True
+
+    @update_repos.setter
+    def update_repos(self, value):
+        self.__dict__['update_repos'] = bool(value)
+
     def __setattr__(self, name, value):
         object.__setattr__(self, name, value)
 

--- a/reckoner/course.py
+++ b/reckoner/course.py
@@ -187,7 +187,11 @@ class Course(object):
                 logging.error(f'ERROR: {command} Failed on {chart.release_name}')
                 if not self.config.continue_on_error:
                     logging.error(f"Stopping '{command}' for chart due to an error! Some of your requested actions may not have been completed!")
-                    logging.error(str(e).splitlines()[2].replace('STDERR: ', ''))
+                    try:
+                        # Try to spit out the actuall useful error but not all responses are int he same format
+                        logging.error(str(e).splitlines()[2].replace('STDERR: ', ''))
+                    except Exception:
+                        logging.error(str(e))
                     break
             finally:
                 # Always grab any results in the chart results

--- a/reckoner/course.py
+++ b/reckoner/course.py
@@ -186,12 +186,12 @@ class Course(object):
                     logging.error(e)
                 logging.error(f'ERROR: {command} Failed on {chart.release_name}')
                 if not self.config.continue_on_error:
-                    logging.error(f"Stopping chart '{command}' due to an error! Some of your charts may not have been installed!")
+                    logging.error(f"Stopping '{command}' for chart due to an error! Some of your requested actions may not have been completed!")
+                    logging.error(str(e).splitlines()[2].replace('STDERR: ', ''))
                     break
             finally:
                 # Always grab any results in the chart results
                 results.append(chart.result)
-
         return results
 
     def install_charts(self, charts_to_install: list) -> List[ChartResult]:
@@ -217,6 +217,15 @@ class Course(object):
         Returns list of `ChartResult()`
         """
         return self.__run_command_for_charts_list('get_manifest', charts_to_manifest)
+
+    def diff_charts(self, charts_to_diff: list) -> List[ChartResult]:
+        """
+        For a list of charts_to_install, run the `get_manifest` method on each chart instance
+        Accepts list of `Chart()`
+        Returns list of `ChartResult()`
+        """
+        return self.__run_command_for_charts_list('diff', charts_to_diff)
+
 
     def only_charts(self, charts_requested: list) -> List[str]:
         """
@@ -274,6 +283,17 @@ class Course(object):
         """
         # return the text of the charts templating
         results = self.get_chart_manifests(self.only_charts(charts_manifests_requested))
+        return results
+
+    def diff(self, chart_diffs_requested: list) -> List[str]:
+        """
+        Accepts chart_diffs_requested, an iterable of the names of the charts
+        to get manifests for. This method compares the charts in the argument to the
+        charts in the course and calls Chart.diff()
+
+        """
+        # return the text of the charts templating
+        results = self.diff_charts(self.only_charts(chart_diffs_requested))
         return results
 
     def plot(self, charts_requested_to_install: list) -> List[ChartResult]:

--- a/reckoner/course.py
+++ b/reckoner/course.py
@@ -94,15 +94,16 @@ class Course(object):
             self.config.course_base_directory
         )
 
-        for repo in self._repositories:
-            # Skip install of repo if it is git based since it will be installed from the chart class
-            if repo.git is None:
-                logging.debug("Installing repository: {}".format(repo))
-                repo.install(chart_name=repo._repository['name'], version=repo._repository.get('version'))
-            else:
-                logging.debug("Skipping git install of repository to later be installed at the chart level: {}".format(repo))
+        if self.config.update_repos:
+            for repo in self._repositories:
+                # Skip install of repo if it is git based since it will be installed from the chart class
+                if repo.git is None:
+                    logging.debug("Installing repository: {}".format(repo))
+                    repo.install(chart_name=repo._repository['name'], version=repo._repository.get('version'))
+                else:
+                    logging.debug("Skipping git install of repository to later be installed at the chart level: {}".format(repo))
 
-        self.helm.repo_update()
+            self.helm.repo_update()
 
         try:
             self._compare_required_versions()

--- a/reckoner/manifests.py
+++ b/reckoner/manifests.py
@@ -28,12 +28,16 @@ class Manifest(object):
         self.document = document
 
     @property
+    def metadata(self):
+        return self.document.get('metadata') or {}
+
+    @property
     def annotations(self):
-        return self.document['metadata'].get('annotations', {})
+        return self.metadata.get('annotations') or {}
 
     @property
     def name(self):
-        return self.document['metadata']['name']
+        return self.metadata.get('name')
 
     @property
     def kind(self):

--- a/reckoner/manifests.py
+++ b/reckoner/manifests.py
@@ -124,7 +124,7 @@ class Manifests(object):
         """
         _new_filtered_manifests = []
         for manifest in self.filtered_manifests:
-            if manifest.get('kind') != kind:
+            if manifest.kind != kind:
                 _new_filtered_manifests.append(manifest)
 
         self.filtered_manifests = _new_filtered_manifests

--- a/reckoner/manifests.py
+++ b/reckoner/manifests.py
@@ -178,7 +178,7 @@ def diff(current: str, new: str, show_hooks: bool = False):
     for current_manifest in current_manifests:
         matching_new_manifest = new_manifests.find_by_kind_and_name(current_manifest.kind, current_manifest.name)
         if not matching_new_manifest:
-            output_lines += ['', '', f'{current_manifest.kind}: {current_manifest.name} exists but will be removed', '']
+            output_lines += ['', '', f'{current_manifest.kind}: "{current_manifest.name}" exists but will be removed', '']
             output_lines += current_manifest.diff(matching_new_manifest)
 
     return "\n".join(output_lines)

--- a/reckoner/manifests.py
+++ b/reckoner/manifests.py
@@ -1,0 +1,184 @@
+# -- coding: utf-8 --
+
+# Copyright 2019 FairwindsOps Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+import difflib
+import logging
+import traceback
+
+from .yaml.handler import Handler as yaml_handler
+
+
+class Manifest(object):
+    def __init__(self, document: dict) -> None:
+        self.document = document
+
+    @property
+    def annotations(self):
+        return self.document['metadata'].get('annotations', {})
+
+    @property
+    def name(self):
+        return self.document['metadata']['name']
+
+    @property
+    def kind(self):
+        return self.document['kind']
+
+    def __str__(self):
+        return yaml_handler.dump(self.document)
+
+    def __eq__(self, other):
+        if not isinstance(other, (Manifetst)):
+            raise TypeError(f"Cannot compare {type(other)} to Manifest()")
+
+        return other.document == self.document
+
+    def __bool__(self):
+        return bool(self.document)
+
+    def diff(self, other, difftype="unified"):
+        """
+        Returns a list of diff lines from the diff between this Manifest
+        instance and the supplied Manifest instance.
+
+        difftype may be "unified" [DEFAULT] or "context"
+        """
+
+        d = difflib.Differ()
+        if difftype.lower() == "unified":
+            differ = difflib.unified_diff
+        elif difftype.lower() == "context":
+            differ = difflib.context_diff
+        else:
+            raise TypeError('difftype argument may only "unified" or "context"')
+
+        return list(
+            differ(
+                str(self).splitlines(),
+                str(other).splitlines(),
+            )
+        )
+
+
+class Manifests(object):
+    """
+    Provides a way to filter yaml documents, based on
+    certain characteristics, from a string or stream containing
+    valid yaml manifests
+    """
+
+    def __init__(self, documents: str) -> None:
+        """
+        Parameters:
+        -----------
+        - manifest: String containing
+        """
+        try:
+            self.all_manifests = [Manifest(document) for document in yaml_handler.load_all(documents.strip())]
+        except Exception as e:
+            logging.error("Error loading manifest")
+            logging.error(e)
+            logging.debug(traceback.format_exc())
+            raise e
+        self.filtered_manifests = self.all_manifests
+
+    def filter_by_annotation_name(self, filter_annotation_key: str) -> None:
+        """
+        Removes manifests from the instances filtered_manifests attribute
+        if they have an annotation that matches the 'filter_annotation_key'
+        parameter
+        """
+
+        _new_filtered_manifests = []
+        for manifest in self.filtered_manifests:
+            if manifest.annotations == {}:
+                logging.debug(f"manifest {manifest.kind} named {manifest.name} has no annotations to filter on")
+                _new_filtered_manifests.append(manifest)
+            else:
+                if filter_annotation_key not in [manifest_annotation_key for manifest_annotation_key in manifest.annotations]:
+                    _new_filtered_manifests.append(manifest)
+                else:
+                    logging.debug(f"Filtering {manifest.kind} named {manifest.name} for {filter_annotation_key} ")
+
+        self.filtered_manifests = _new_filtered_manifests
+
+    def filter_by_kind(self, kind: str) -> None:
+        """
+        Removes manifests from the instances filtered_manifests attribute
+        if they are of the kind specified in the 'kind' parameter
+        """
+        _new_filtered_manifests = []
+        for manifest in self.filtered_manifests:
+            if manifest.get('kind') != kind:
+                _new_filtered_manifests.append(manifest)
+
+        self.filtered_manifests = _new_filtered_manifests
+
+    def find_by_kind_and_name(self, kind: str, name: str) -> str:
+        """
+        Returns the manifest from the filtered manifests
+        that matches the paramters kind and name, as a string
+        """
+        try:
+            return [
+                manifest
+                for manifest
+                in self.filtered_manifests
+                if manifest.kind == kind
+                and manifest.name == name
+            ][0]
+        except IndexError:
+            pass
+
+        return Manifest("")
+
+    def __iter__(self):
+        for manifest in self.filtered_manifests:
+            yield manifest
+
+
+def diff(current: str, new: str, show_hooks: bool = False):
+    current_manifests = Manifests(current)
+    new_manifests = Manifests(new)
+
+    for _manifest in [current_manifests, new_manifests]:
+        if show_hooks is False:
+            _manifest.filter_by_annotation_name('helm.sh/hook')
+
+    output_lines = []
+    for new_manifest in new_manifests:
+        diff_lines = []
+        matching_existing_manifest = current_manifests.find_by_kind_and_name(new_manifest.kind, new_manifest.name)
+
+        manifest_separator_message = f'{new_manifest.kind}: "{new_manifest.name}"'
+        if not matching_existing_manifest:
+            manifest_separator_message += " does not exist and will be added "
+        manifest_separator_lines = ['', manifest_separator_message]
+
+        diff_lines = matching_existing_manifest.diff(new_manifest)
+        if diff_lines:
+            output_lines += manifest_separator_lines
+            output_lines += diff_lines
+
+    for current_manifest in current_manifests:
+        matching_new_manifest = new_manifests.find_by_kind_and_name(current_manifest.kind, current_manifest.name)
+        if not matching_new_manifest:
+            output_lines += ['', '', f'{current_manifest.kind}: {current_manifest.name} exists but will be removed', '']
+            output_lines += current_manifest.diff(matching_new_manifest)
+
+    return "\n".join(output_lines)

--- a/reckoner/reckoner.py
+++ b/reckoner/reckoner.py
@@ -122,6 +122,14 @@ class Reckoner(object):
             logging.error(error)
             raise ReckonerCommandException('Failed to find any valid charts to show manifests for.')
 
+    def diff(self, charts: List[str] = [] ):
+        selected_charts = charts or [chart._release_name for chart in self.course.charts]
+        try:
+            return self.course.diff(selected_charts)
+        except NoChartsToInstall as error:
+            logging.error(error)
+            raise ReckonerCommandException('Failed to find any valid charts to show diff for.')
+
 
     def add_result(self, result: ChartResult) -> None:
         self.results.add_result(result)

--- a/reckoner/reckoner.py
+++ b/reckoner/reckoner.py
@@ -106,6 +106,31 @@ class Reckoner(object):
             logging.error(error)
             raise ReckonerCommandException('Failed to find any valid charts to install.')
 
+    def update(self, charts: List[str] = []) -> None:
+        """
+        Description:
+        - Calls update on course instance.
+
+        Arguments:
+        - charts (default: []): list or tuple of release_names from the course. That list of
+          charts will be installed or if the argument is empty, All charts in the course will be installed
+
+        Returns:
+        - None
+
+        """
+        selected_charts = charts or [chart._release_name for chart in self.course.charts]
+        try:
+            plot_results = self.course.update(selected_charts)
+            for chart_result in plot_results:
+                if chart_result:
+                    self.add_result(chart_result)
+                else:
+                    raise Exception("Didn't expect None as a chart result...")
+        except NoChartsToInstall as error:
+            logging.error(error)
+            raise ReckonerCommandException('Failed to find any valid charts to install.')
+
     def template(self, charts: List[str] = [] ):
         selected_charts = charts or [chart._release_name for chart in self.course.charts]
         try:

--- a/reckoner/tests/files/configmap.yaml
+++ b/reckoner/tests/files/configmap.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: reckoner-test-configmap
+data:
+  foo: bear

--- a/reckoner/tests/files/configmap.yaml
+++ b/reckoner/tests/files/configmap.yaml
@@ -1,5 +1,6 @@
 ---
-apiVersion: v1
+# Source test-configmap
+  apiVersion: v1
 kind: ConfigMap
 metadata:
   name: reckoner-test-configmap

--- a/reckoner/tests/files/service.yaml
+++ b/reckoner/tests/files/service.yaml
@@ -1,4 +1,5 @@
 ---
+# Source test-service
 apiVersion: v1
 kind: Service
 metadata:

--- a/reckoner/tests/files/service.yaml
+++ b/reckoner/tests/files/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reckoner-test-service
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: 4141
+      protocol: TCP
+      name: reckoner
+  selector:
+    app: reckoner
+    release: reckoner

--- a/reckoner/tests/files/templates.yaml
+++ b/reckoner/tests/files/templates.yaml
@@ -95,3 +95,26 @@ metadata:
     annotations:
       helm.sh/hook: test-success
 spec: {}
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      name: external-dns
+      namespace: prometheus-operator
+      labels:
+        app: prometheus-operator-prometheus
+        chart: prometheus-operator-8.13.4
+        release: "prometheus-operator"
+        heritage: "Helm"
+    spec:
+      endpoints:
+        - port: http
+      namespaceSelector:
+        matchNames:
+        - external-dns
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: external-dns

--- a/reckoner/tests/files/templates.yaml
+++ b/reckoner/tests/files/templates.yaml
@@ -88,6 +88,7 @@ spec:
         hostPath:
           path: /srv/kubernetes/aws-iam-authenticator/
 ---
+# Source: aws-iam-authenticator/templates/pod.yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -96,6 +97,7 @@ metadata:
       helm.sh/hook: test-success
 spec: {}
 ---
+# Source: aws-iam-authenticator/templates/list1.yaml
 apiVersion: v1
 kind: List
 items:
@@ -118,3 +120,43 @@ items:
       selector:
         matchLabels:
           app.kubernetes.io/name: external-dns
+---
+# Source: aws-iam-authenticator/templates/list2.yaml
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      name: external-dns2
+      namespace: prometheus-operator
+      labels:
+        app: prometheus-operator-prometheus
+        chart: prometheus-operator-8.13.4
+        release: "prometheus-operator"
+        heritage: "Helm"
+    spec:
+      endpoints:
+        - port: http
+      namespaceSelector:
+        matchNames:
+        - external-dns2
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: external-dns2
+---
+# Source test-service
+apiVersion: v1
+kind: Service
+metadata:
+  name: reckoner-test-service
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: 4141
+      protocol: TCP
+      name: reckoner
+  selector:
+    app: reckoner
+    release: reckoner

--- a/reckoner/tests/files/templates.yaml
+++ b/reckoner/tests/files/templates.yaml
@@ -1,0 +1,97 @@
+---
+# Source: aws-iam-authenticator/templates/configmap.yaml
+# Copyright 2017 by the contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: a2-aws-iam-authenticator
+  labels:
+    k8s-app: aws-iam-authenticator
+data:
+  config.yaml: ""
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: a2-aws-iam-authenticator
+  labels:
+    app.kubernetes.io/name: aws-iam-authenticator
+    app.kubernetes.io/instance: a2
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: aws-iam-authenticator-v1.3.2
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: aws-iam-authenticator
+      app.kubernetes.io/instance: a2
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-iam-authenticator
+        app.kubernetes.io/instance: a2
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - key: CriticalAddonsOnly
+        operator: Exists
+      containers:
+      - name: aws-iam-authenticator
+        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.4.0"
+        args:
+        - server
+        - --config=/etc/aws-iam-authenticator/config.yaml
+        - --state-dir=/var/aws-iam-authenticator/
+        - --generate-kubeconfig=/etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml
+        - --kubeconfig-pregenerated=true
+
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        volumeMounts:
+        - name: config
+          mountPath: /etc/aws-iam-authenticator/
+        - name: state
+          mountPath: /var/aws-iam-authenticator/
+        - name: output
+          mountPath: /etc/kubernetes/aws-iam-authenticator/
+
+      volumes:
+      - name: config
+        configMap:
+          name: a2-aws-iam-authenticator
+      - name: output
+        hostPath:
+          path: /srv/kubernetes/aws-iam-authenticator/
+      - name: state
+        hostPath:
+          path: /srv/kubernetes/aws-iam-authenticator/
+---
+apiVersion: v1
+kind: Pod
+metadata:
+    name: "reckoner-test-hook-pod"
+    annotations:
+      helm.sh/hook: test-success
+spec: {}

--- a/reckoner/tests/files/templates2.yaml
+++ b/reckoner/tests/files/templates2.yaml
@@ -1,0 +1,97 @@
+---
+# Source: aws-iam-authenticator/templates/configmap.yaml
+# Copyright 2017 by the contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: a2-aws-iam-authenticator
+  labels:
+    k8s-app: aws-iam-authenticator
+data:
+  config.yaml: ""
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: a2-aws-iam-authenticator-test2
+  labels:
+    app.kubernetes.io/name: aws-iam-authenticator
+    app.kubernetes.io/instance: a2
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: aws-iam-authenticator-v1.3.2
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: aws-iam-authenticator
+      app.kubernetes.io/instance: a2
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-iam-authenticator
+        app.kubernetes.io/instance: a2
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - key: CriticalAddonsOnly
+        operator: Exists
+      containers:
+      - name: aws-iam-authenticator
+        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.4.0"
+        args:
+        - server
+        - --config=/etc/aws-iam-authenticator/config.yaml
+        - --state-dir=/var/aws-iam-authenticator/
+        - --generate-kubeconfig=/etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml
+        - --kubeconfig-pregenerated=true
+
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        volumeMounts:
+        - name: config
+          mountPath: /etc/aws-iam-authenticator/
+        - name: state
+          mountPath: /var/aws-iam-authenticator/
+        - name: output
+          mountPath: /etc/kubernetes/aws-iam-authenticator/
+
+      volumes:
+      - name: config
+        configMap:
+          name: a2-aws-iam-authenticator
+      - name: output
+        hostPath:
+          path: /srv/kubernetes/aws-iam-authenticator/
+      - name: state
+        hostPath:
+          path: /srv/kubernetes/aws-iam-authenticator/
+---
+apiVersion: v1
+kind: Pod
+metadata:
+    name: "reckoner-test-hook-pod"
+    annotations:
+      helm.sh/hook: test-success
+spec: {}

--- a/reckoner/tests/files/templates2.yaml
+++ b/reckoner/tests/files/templates2.yaml
@@ -22,6 +22,7 @@ metadata:
 data:
   config.yaml: ""
 ---
+# Source: daemonset
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -88,6 +89,7 @@ spec:
         hostPath:
           path: /srv/kubernetes/aws-iam-authenticator/
 ---
+# Source: pod
 apiVersion: v1
 kind: Pod
 metadata:
@@ -95,3 +97,27 @@ metadata:
     annotations:
       helm.sh/hook: test-success
 spec: {}
+---
+# Source: aws-iam-authenticator/templates/list1.yaml
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      name: external-dns-new
+      namespace: prometheus-operator
+      labels:
+        app: prometheus-operator-prometheus
+        chart: prometheus-operator-8.13.4
+        release: "prometheus-operator"
+        heritage: "Helm"
+    spec:
+      endpoints:
+        - port: http
+      namespaceSelector:
+        matchNames:
+        - external-dns
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: external-dns

--- a/reckoner/tests/files/templates3.yaml
+++ b/reckoner/tests/files/templates3.yaml
@@ -1,0 +1,97 @@
+---
+# Source: aws-iam-authenticator/templates/configmap.yaml
+# Copyright 2017 by the contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: a2-aws-iam-authenticator
+  labels:
+    k8s-app: aws-iam-authenticator-test
+data:
+  config.yaml: ""
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: a2-aws-iam-authenticator
+  labels:
+    app.kubernetes.io/name: aws-iam-authenticator
+    app.kubernetes.io/instance: a2
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: aws-iam-authenticator-v1.3.2
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: aws-iam-authenticator
+      app.kubernetes.io/instance: a2
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-iam-authenticator
+        app.kubernetes.io/instance: a2
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - key: CriticalAddonsOnly
+        operator: Exists
+      containers:
+      - name: aws-iam-authenticator
+        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.4.0"
+        args:
+        - server
+        - --config=/etc/aws-iam-authenticator/config.yaml
+        - --state-dir=/var/aws-iam-authenticator/
+        - --generate-kubeconfig=/etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml
+        - --kubeconfig-pregenerated=true
+
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        volumeMounts:
+        - name: config
+          mountPath: /etc/aws-iam-authenticator/
+        - name: state
+          mountPath: /var/aws-iam-authenticator/
+        - name: output
+          mountPath: /etc/kubernetes/aws-iam-authenticator/
+
+      volumes:
+      - name: config
+        configMap:
+          name: a2-aws-iam-authenticator
+      - name: output
+        hostPath:
+          path: /srv/kubernetes/aws-iam-authenticator/
+      - name: state
+        hostPath:
+          path: /srv/kubernetes/aws-iam-authenticator/
+---
+apiVersion: v1
+kind: Pod
+metadata:
+    name: "reckoner-test-hook-pod-2"
+    annotations:
+      helm.sh/hook: test-success
+spec: {}

--- a/reckoner/tests/test_cli.py
+++ b/reckoner/tests/test_cli.py
@@ -181,15 +181,14 @@ class TestCliTemplate(unittest.TestCase):
                 '--run-all',
                 '--helm-args',
                 '--heading',
-                '--only',
-                '--continue-on-error',
+                '--only'
             ],
             'argument': [
                 'course_file',
             ]
         }
 
-        assert_required_params(required, cli.plot.params)
+        assert_required_params(required, cli.template.params)
 
 class TestCliGetManifests(unittest.TestCase):
     @mock.patch('reckoner.cli.validate_course_file')
@@ -243,6 +242,128 @@ class TestCliGetManifests(unittest.TestCase):
                 '--run-all',
                 '--helm-args',
                 '--heading',
+                '--only'
+            ],
+            'argument': [
+                'course_file',
+            ]
+        }
+
+        assert_required_params(required, cli.get_manifests.params)
+
+class TestCliDiff(unittest.TestCase):
+    @mock.patch('reckoner.cli.validate_course_file')
+    @mock.patch('reckoner.cli.Reckoner', autospec=True)
+    def test_template_exists(self, reckoner_mock, validation_mock):
+        """Assure we have a get_manifests command and it calls reckoner get-manifests"""
+        reckoner_instance = reckoner_mock()
+        reckoner_instance.results = mock.MagicMock(has_errors=False)
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open('nonexistent.file', 'wb') as fake_file:
+                fake_file.write(''.encode())
+
+            result = runner.invoke(cli.diff, args=['nonexistent.file', '--run-all'])
+
+        self.assertEqual(0, result.exit_code, result.output)
+        reckoner_instance.diff.assert_called_once()
+
+    @mock.patch('reckoner.cli.validate_course_file')
+    @mock.patch('reckoner.cli.Reckoner', autospec=True)
+    def test_diff_has_correct_exit_code_with_errors(self, reckoner_mock, validation_mock):
+        """Assure we have a get_manifests command and it calls reckoner get_manifests"""
+        reckoner_instance = reckoner_mock()
+        reckoner_instance.results = mock.MagicMock(has_errors=True)
+        reckoner_instance.results.results_with_errors = [None]
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open('nonexistent.file', 'wb') as fake_file:
+                fake_file.write(''.encode())
+
+            result = runner.invoke(cli.diff, args=['nonexistent.file'])
+
+        self.assertEqual(1, result.exit_code, result.output)
+
+    @mock.patch('reckoner.cli.Reckoner', autospec=True)
+    def test_diff_handles_exception(self, reckoner_mock):
+        """Assure we have a get_manifests command and it calls reckoner get_manifests"""
+        reckoner_mock.side_effect = [ReckonerException("had some error")]
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open('nonexistent.file', 'wb') as fake_file:
+                fake_file.write(''.encode())
+
+            result = runner.invoke(cli.diff, args=['nonexistent.file', '--run-all'])
+
+        self.assertEqual(1, result.exit_code, result.output)
+
+    def test_diff_options(self):
+        required = {
+            'option': [
+                '--run-all',
+                '--helm-args',
+                '--heading',
+                '--only'
+            ],
+            'argument': [
+                'course_file',
+            ]
+        }
+
+        assert_required_params(required, cli.diff.params)
+
+class TestCliUpdate(unittest.TestCase):
+    @mock.patch('reckoner.cli.validate_course_file')
+    @mock.patch('reckoner.cli.Reckoner', autospec=True)
+    def test_template_exists(self, reckoner_mock, validation_mock):
+        """Assure we have a get_manifests command and it calls reckoner get-manifests"""
+        reckoner_instance = reckoner_mock()
+        reckoner_instance.results = mock.MagicMock(has_errors=False)
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open('nonexistent.file', 'wb') as fake_file:
+                fake_file.write(''.encode())
+
+            result = runner.invoke(cli.update, args=['nonexistent.file', '--run-all'])
+
+        self.assertEqual(0, result.exit_code, result.output)
+        reckoner_instance.update.assert_called_once()
+
+    @mock.patch('reckoner.cli.validate_course_file')
+    @mock.patch('reckoner.cli.Reckoner', autospec=True)
+    def test_get_manifests_has_correct_exit_code_with_errors(self, reckoner_mock, validation_mock):
+        """Assure we have a get_manifests command and it calls reckoner get_manifests"""
+        reckoner_instance = reckoner_mock()
+        reckoner_instance.results = mock.MagicMock(has_errors=True)
+        reckoner_instance.results.results_with_errors = [None]
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open('nonexistent.file', 'wb') as fake_file:
+                fake_file.write(''.encode())
+
+            result = runner.invoke(cli.update, args=['nonexistent.file'])
+
+        self.assertEqual(1, result.exit_code, result.output)
+
+    @mock.patch('reckoner.cli.Reckoner', autospec=True)
+    def test_get_manifests_handles_exception(self, reckoner_mock):
+        """Assure we have a get_manifests command and it calls reckoner get_manifests"""
+        reckoner_mock.side_effect = [ReckonerException("had some error")]
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open('nonexistent.file', 'wb') as fake_file:
+                fake_file.write(''.encode())
+
+            result = runner.invoke(cli.update, args=['nonexistent.file', '--run-all'])
+
+        self.assertEqual(1, result.exit_code, result.output)
+
+    def test_get_manifest_options(self):
+        required = {
+            'option': [
+                '--run-all',
+                '--helm-args',
+                '--heading',
                 '--only',
                 '--continue-on-error',
             ],
@@ -251,7 +372,7 @@ class TestCliGetManifests(unittest.TestCase):
             ]
         }
 
-        assert_required_params(required, cli.plot.params)
+        assert_required_params(required, cli.update.params)
 
 def assert_required_params(required_options, list_of_cli_params):
     all_params = {}

--- a/reckoner/tests/test_config.py
+++ b/reckoner/tests/test_config.py
@@ -47,3 +47,16 @@ class TestConfig(unittest.TestCase):
         # relative path to /some/fake/path
         config.course_path = '../../relative/course.yml'
         self.assertEqual('/some/relative', config.course_base_directory)
+
+    def test_update_repos(self):
+        config = Config()
+        # Test default True
+        self.assertTrue(config.update_repos)
+
+        # Test set False
+        config.update_repos = False
+        self.assertFalse(config.update_repos)
+
+        # Test set True
+        config.update_repos = True
+        self.assertTrue(config.update_repos)

--- a/reckoner/tests/test_manifests.py
+++ b/reckoner/tests/test_manifests.py
@@ -34,7 +34,7 @@ class TestManifests(unittest.TestCase):
             self.assertIsInstance(manifest, (Manifest))
 
         # There number of documents in the test file should equal the number of manifets
-        self.assertEqual(len(self.manifests.all_manifests), 4)
+        self.assertEqual(len(self.manifests.all_manifests), 6)
 
         # Prior to modification, all_manifests == filtered_manifest
         self.assertEqual(self.manifests.all_manifests, self.manifests.filtered_manifests)
@@ -48,20 +48,27 @@ class TestManifests(unittest.TestCase):
             annotation_keys = [key for key in manifest.annotations]
             self.assertNotIn('"helm.sh/hook"', annotation_keys)
 
-        self.assertEqual(len(self.manifests.filtered_manifests), 3)
+        self.assertEqual(len(self.manifests.filtered_manifests), 5)
 
-    def test_find_by_kind_and_name(self):
-        found = self.manifests.find_by_kind_and_name("ConfigMap", "a2-aws-iam-authenticator")
+    def test_find_congruent_manifest(self):
+        with open('./reckoner/tests/files/service.yaml') as f:
+            document = f.read()
+        service_manifest = Manifest(yaml_handler.load(document))
+
+        print(service_manifest.kind)
+
+        found = self.manifests.find_congruent_manifest(service_manifest)
+        print(found)
         self.assertIsInstance(found, (Manifest))
-        self.assertEqual(found.kind, 'ConfigMap')
-        self.assertEqual(found.name, 'a2-aws-iam-authenticator')
+        self.assertEqual(found.kind, 'Service')
+        self.assertEqual(found.name, 'reckoner-test-service')
         self.assertEqual(found.annotations, {})
 
     def test_filter_by_kind(self):
         self.manifests.filter_by_kind('Pod')
         self.manifests.filter_by_kind('DaemonSet')
         self.manifests.filter_by_kind('List')
-        self.assertEqual(len(self.manifests.filtered_manifests), 1)
+        self.assertEqual(len(self.manifests.filtered_manifests), 2)
         self.assertEqual(self.manifests.filtered_manifests[0].kind, 'ConfigMap')
 
 

--- a/reckoner/tests/test_manifests.py
+++ b/reckoner/tests/test_manifests.py
@@ -34,7 +34,7 @@ class TestManifests(unittest.TestCase):
             self.assertIsInstance(manifest, (Manifest))
 
         # There number of documents in the test file should equal the number of manifets
-        self.assertEqual(len(self.manifests.all_manifests), 3)
+        self.assertEqual(len(self.manifests.all_manifests), 4)
 
         # Prior to modification, all_manifests == filtered_manifest
         self.assertEqual(self.manifests.all_manifests, self.manifests.filtered_manifests)
@@ -48,7 +48,7 @@ class TestManifests(unittest.TestCase):
             annotation_keys = [key for key in manifest.annotations]
             self.assertNotIn('"helm.sh/hook"', annotation_keys)
 
-        self.assertEqual(len(self.manifests.filtered_manifests), 2)
+        self.assertEqual(len(self.manifests.filtered_manifests), 3)
 
     def test_find_by_kind_and_name(self):
         found = self.manifests.find_by_kind_and_name("ConfigMap", "a2-aws-iam-authenticator")
@@ -60,7 +60,7 @@ class TestManifests(unittest.TestCase):
     def test_filter_by_kind(self):
         self.manifests.filter_by_kind('Pod')
         self.manifests.filter_by_kind('DaemonSet')
-        print([str(m) for m in self.manifests.filtered_manifests])
+        self.manifests.filter_by_kind('List')
         self.assertEqual(len(self.manifests.filtered_manifests), 1)
         self.assertEqual(self.manifests.filtered_manifests[0].kind, 'ConfigMap')
 

--- a/reckoner/tests/test_manifests.py
+++ b/reckoner/tests/test_manifests.py
@@ -25,7 +25,7 @@ class TestManifests(unittest.TestCase):
 
     def test_manifest_load_error(self):
         with self.assertRaises(Exception):
-            manifests = Manifests("---\njunk: - information: that | does , not play")
+            Manifests("---\njunk: - information: that | does , not play")
 
     def test_manifests_loaded(self):
 
@@ -89,15 +89,6 @@ class TestManifest(unittest.TestCase):
 
 
 class TestDiff(unittest.TestCase):
-
-    def test_no_difference(self):
-        with open('./reckoner/tests/files/templates.yaml') as templates:
-            t1 = templates.read()
-
-        with open('./reckoner/tests/files/templates.yaml') as templates:
-            t2 = templates.read()
-
-        self.assertEqual(diff(t1, t2), '')
 
     def test_no_difference(self):
         with open('./reckoner/tests/files/templates.yaml') as templates:

--- a/reckoner/yaml/handler.py
+++ b/reckoner/yaml/handler.py
@@ -41,9 +41,29 @@ class Handler(object):
         return y
 
     @classmethod
+    def load_all(cls, yaml_file: BufferedReader):
+        try:
+            y = cls.yaml.load_all(yaml_file)
+        except DuplicateKeyError as err:
+            logging.error(_clean_duplicate_key_message(str(err)))
+            raise ReckonerConfigException(
+                "Duplicate key found while loading your course YAML, please remove the duplicate key shown above.")
+        except Exception as err:
+            logging.error("Unexpected error when parsing yaml. See debug for more details.")
+            logging.debug(err)
+            raise err
+        return y
+
+    @classmethod
     def dump(cls, data: dict) -> str:
         temp_file = StringIO()
         cls.yaml.dump(data, temp_file)
+        return temp_file.getvalue()
+
+    @classmethod
+    def dump_all(cls, data: dict) -> str:
+        temp_file = StringIO()
+        cls.yaml.dump_all(data, temp_file)
         return temp_file.getvalue()
 
 


### PR DESCRIPTION
This adds `diff` to the list of commands. It compares
   the output of `template`  and  `get_manifests`  using `difflib` . Whereas
   most other commands return a `HelmCommandResponse` response, that was not
   really work able without major re-write here because there is only a single
   instance of `self.response`  in the  class. Calling `template`  and
   `get_manifests` in succession from an instnace of the Chart class
   overwrites the previous command's `self.response` . Less than ideal, but I
   created hidden methods to return the content of those commands that are
   then called by the new `diff`  command and I return the string
   representation of the diff as `self.resposne`  but it is not an instance of
   HelmResponse becaue it is not, technically, a HelmResponse