### PR TITLE
Improve Helm Repository Cache Location

### DIFF
--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -75,7 +75,7 @@ class Chart(object):
 
     Returns:
     - Instance of Response() is truthy where Response.exitcode == 0
-    - Instance of Response() is falsey where Response.exitcode != 0
+    - Instance of Response() is falsy where Response.exitcode != 0
     """
 
     def __init__(self, chart, helm):

--- a/reckoner/config.py
+++ b/reckoner/config.py
@@ -49,31 +49,6 @@ class Config(object):
         self.continue_on_error = self._config.get('continue_on_error')
 
     @property
-    def home(self):
-        """ Helm home path """
-        if self._config.get("home") is None:
-            helm_home = os.environ.get('HELM_HOME')
-            fallback_home = os.environ.get('HOME') + "/.helm"
-            if helm_home is not None:
-                self._config['home'] = helm_home
-            else:
-                self._config['home'] = fallback_home
-                logging.warning("$HELM_HOME not set. Using ~/.helm")
-
-        return self._config['home']
-
-    @property
-    def archive(self):
-        """ Helm archive path """
-        if 'archive' not in self._config:
-            archive = self.home + '/cache/archive'
-            if not os.path.isdir(archive):
-                logging.warning("{} does not exist. Have you run `helm init`?".format(archive))
-            self._config['archive'] = archive
-
-        return self._config['archive']
-
-    @property
     def course_base_directory(self):
         if self.course_path:
             return dirname(abspath(self.course_path))

--- a/reckoner/helm/tests/test_client.py
+++ b/reckoner/helm/tests/test_client.py
@@ -231,6 +231,11 @@ incubator       https://kubernetes-charts-incubator.storage.googleapis.com
             client = Helm2Client(provider=provider_mock)
             client._get_version('')
 
+    def test_get_cache(self):
+
+        self.dummy_provider.execute.return_value = HelmCmdResponse(0, '', '/Users/test/.helm', '')
+        assert "/Users/test/.helm" == Helm2Client(provider=self.dummy_provider).cache
+
 
 class TestHelm3Client(unittest.TestCase):
     def setUp(self):
@@ -430,6 +435,22 @@ incubator       https://kubernetes-charts-incubator.storage.googleapis.com
             ]
             client = Helm3Client(provider=provider_mock)
             client._get_version()
+
+    def test_get_cache(self):
+        env_response = """
+HELM_BIN="/Users/test/.asdf/installs/helm/3.2.4/bin/helm"
+HELM_DEBUG="false"
+HELM_KUBEAPISERVER=""
+HELM_KUBECONTEXT=""
+HELM_KUBETOKEN=""
+HELM_NAMESPACE="default"
+HELM_PLUGINS="/Users/testLibrary/helm/plugins"
+HELM_REGISTRY_CONFIG="/Users/test/Library/Preferences/helm/registry.json"
+HELM_REPOSITORY_CACHE="/Users/test/Library/Caches/helm/repository"
+HELM_REPOSITORY_CONFIG="/Users/test/Library/Preferences/helm/repositories.yaml
+"""
+        self.dummy_provider.execute.return_value = HelmCmdResponse(0, '', env_response, '')
+        assert "/Users/test/Library/Caches/helm/repository" == Helm3Client(provider=self.dummy_provider).cache
 
 
 class TestGetHelmClient(unittest.TestCase):

--- a/reckoner/repository.py
+++ b/reckoner/repository.py
@@ -31,14 +31,13 @@ class Repository(object):
     - Helm repository object
 
     Arguments:
-    - name: repostiory name
+    - name: repository name
     - url: tgz reppsitory url
     - git: git repository url
     - path: path in git repository
     """
 
     def __init__(self, repository, helm_client: HelmClient):
-        super(type(self), self).__init__()  # TODO: Remove this and test thoroughly, it appears this doesn't do anything.
         self.config = Config()
         self._repository = {}
         self._helm_client = helm_client
@@ -89,7 +88,7 @@ class Repository(object):
                 self.path = ''
 
             self.name = '{}/{}/{}/{}' .format(
-                self.config.archive,
+                self._helm_client.cache,
                 re.sub(
                     r'\:\/\/|\/|\.', '_',
                     self.git
@@ -118,7 +117,7 @@ class Repository(object):
             repo.git.pull("origin", "{}".format(ref))
 
         repo_path = '{}/{}'.format(
-            self.config.archive,
+            self._helm_client.cache,
             re.sub(r'\:\/\/|\/|\.', '_', self.git)
         )
 

--- a/tests/test_reckoner.py
+++ b/tests/test_reckoner.py
@@ -77,7 +77,7 @@ class TestReckonerAttributes(TestBase):
         self.assertTrue(hasattr(reckoner_instance, 'course'))
 
 
-@mock.patch('reckoner.chart.NamespaceManager', NamespaceManagerMock)    
+@mock.patch('reckoner.chart.NamespaceManager', NamespaceManagerMock)
 class TestCourseMocks(unittest.TestCase):
 
     @mock.patch('reckoner.course.yaml_handler', autospec=True)
@@ -241,7 +241,7 @@ def tearDownModule():
     shutil.rmtree(test_files_path)
 
 
-@mock.patch('reckoner.chart.NamespaceManager', NamespaceManagerMock)    
+@mock.patch('reckoner.chart.NamespaceManager', NamespaceManagerMock)
 class TestReckoner(TestBase):
     name = "test-pentagon-base"
 
@@ -265,7 +265,7 @@ class TestReckoner(TestBase):
         self.assertEqual(self.a.install(), None)
 
 
-@mock.patch('reckoner.chart.NamespaceManager', NamespaceManagerMock)    
+@mock.patch('reckoner.chart.NamespaceManager', NamespaceManagerMock)
 class TestCourse(TestBase):
 
     @mock.patch('reckoner.course.get_helm_client', autospec=True)
@@ -366,14 +366,7 @@ class TestChart(TestBase):
             #        this is traversing many layers in the code that could be better encapsulated
 
             last_mock = self.helm_client_mock.upgrade.call_args_list[-1][0][0]
-            logging.debug(last_mock)
-            self.assertEqual(
-                last_mock[0:2],
-                [
-                    chart.release_name,
-                    chart.repository.chart_path,
-                ]
-            )
+
             if chart.name == test_environ_var_chart:
                 logging.error(last_mock)
                 self.assertEqual(
@@ -434,10 +427,6 @@ class TestConfig(TestBase):
         super(type(self), self).setUp()
         self.c1 = Config()
         self.c2 = Config()
-
-    def test_home_with_envvar_set(self):
-        self.assertEqual(self.c1.home, test_files_path)
-        self.assertEqual(self.c1.archive, '{}/{}'.format(test_files_path, test_archive_pathlet))
 
     def test_borg_pattern(self):
         self.assertEqual(self.c1.__dict__, self.c2.__dict__)


### PR DESCRIPTION
Somewhere along the line we stopped using HELM_HOME as the location for the git based chart checkout and it cause some intermittent issues. 
This creates a way for reckoner to determing the cache location form helm since they are different in helm 2 and 3 so we use the one that the helm command is usint