### PR TITLE
Adjust dry-run behavior for update, get-manifest, template

### DIFF
--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -306,6 +306,7 @@ class Chart(object):
 
         try:
             if self.requires_update:
+                logging.info(f"Release {self.name} requires updating.")
                 self.__pre_command(default_namespace, default_namespace_management, context)
                 self.manage_namespace()
 
@@ -370,8 +371,10 @@ class Chart(object):
                 self._append_arg('--kube-context {}'.format(self.context))
 
             # Add debug arguments
+            # No --dry-run flag for get manifest
             for debug_arg in self.debug_args:
-                self._append_arg(debug_arg)
+                if debug_arg != '--dry-run':
+                    self._append_arg(debug_arg)
 
             # Perform the template with the arguments
             return self.helm.get_manifest(self.args, plugin=self.plugin)
@@ -402,9 +405,10 @@ class Chart(object):
         Returns true if there is any differences between the installed release and the
         templates that would be generated from this run
         """
-        if self.__diff_response() == "":
+        diff = self.__diff_response()
+        if diff == "":
             return False
-
+        logging.debug(f"\"{diff}\" != \"\"")
         return True
 
     def diff(self, default_namespace=None, default_namespace_management={}, context=None) -> None:

--- a/reckoner/cli.py
+++ b/reckoner/cli.py
@@ -129,7 +129,7 @@ def plot(ctx, run_all, log_level, course_file=None, dry_run=False, debug=False, 
                                   'configuring how helm connects to tiller.', multiple=True)
 @click.option("--log-level", default="INFO", help="Log Level. [INFO | DEBUG | WARN | ERROR]. (default=INFO)")
 @update_repos_option
-def template(ctx, only, run_all, log_level, course_file=None, helm_args=None, update_repos=True):
+def template(ctx, only, run_all, log_level, course_file=None, helm_args=None, dry_run=False, update_repos=True):
     """Output the template of the chart or charts as they would be installed or upgraded"""
 
     coloredlogs.install(level=log_level)
@@ -280,8 +280,6 @@ def diff(ctx, only, run_all, log_level, course_file=None, helm_args=None, update
 @cli.command()
 @click.pass_context
 @click.argument('course_file', type=click.File('rb'))
-@click.option("--dry-run", is_flag=True, help='Pass --dry-run to helm so no action is taken. Implies --debug and '
-              'skips hooks.')
 @click.option("--debug", is_flag=True, help='DEPRECATED - use --log-level=DEBUG as a parameter to `reckoner` instead. May be used with or without `--dry-run`. Or, pass `--debug` to --helm-args')
 @click.option("--run-all", "-a", "run_all", is_flag=True, help='Run all charts in the course.', cls=Mutex, not_required_if=["only"])
 @click.option("--only", "--heading", "-o", "only", metavar="<chart>", help='Only run a specific chart by name', multiple=True, cls=Mutex,
@@ -308,7 +306,7 @@ def update(ctx, run_all, log_level, course_file=None, dry_run=False, debug=False
         with open(course_file.name, 'rb') as course_file_stream:
             validate_course_file(course_file_stream)
         # Load Reckoner
-        r = Reckoner(course_file=course_file, dryrun=dry_run, debug=debug, helm_args=helm_args,
+        r = Reckoner(course_file=course_file, debug=debug, helm_args=helm_args,
                      continue_on_error=continue_on_error, create_namespace=create_namespace)
         # Convert tuple to list
         only = list(only)


### PR DESCRIPTION
removing dryrun from reckoner tempalte, its not necessary, removed dryrun from update, also unnecsasary, still gated the debug args in the get-manifest flow because it breaks stuff if its there

Fixed #221