### PR TITLE
Handle case where chart generates an empty yaml doc

### DIFF
--- a/reckoner/manifests.py
+++ b/reckoner/manifests.py
@@ -104,7 +104,7 @@ class Manifests(object):
         - manifest: String containing
         """
         try:
-            self.all_manifests = [Manifest(document) for document in yaml_handler.load_all(documents.strip())]
+            self.all_manifests = [Manifest(document) for document in yaml_handler.load_all(documents.strip()) if document]
         except Exception as e:
             logging.error("Error loading manifest")
             logging.error(e)


### PR DESCRIPTION
There is an edge during a `diff` here when a chart generates an empty yaml document. In that case `document` ends up being `None` and that leads to eventually trying to do `self.document.get('metadata')` in `def manifest(self)` which promptly explodes. This just removes empty manifests from the list of all manifests early in the process.