### PR TITLE
Adding a lint command

### DIFF
--- a/reckoner/cli.py
+++ b/reckoner/cli.py
@@ -25,7 +25,7 @@ from reckoner.meta import __version__
 from reckoner.reckoner import Reckoner
 from reckoner.config import Config
 
-from reckoner.schema_validator.course import validate_course_file
+from reckoner.schema_validator.course import validate_course_file, lint_course_file
 
 class Mutex(click.Option):
     def __init__(self, *args, **kwargs):
@@ -330,6 +330,20 @@ def update(ctx, run_all, log_level, course_file=None, dry_run=False, debug=False
             click.echo(click.style(str(result), fg="bright_red"))
         ctx.exit(1)
 
+@cli.command()
+@click.pass_context
+@log_level_option
+@course_file_argument
+def lint(ctx, log_level, course_file=None):
+    """ Validate the course file schema """
+    coloredlogs.install(level=log_level)
+    try:
+        with open(course_file.name, 'rb') as course_file_stream:
+            validate_course_file(course_file_stream)
+    except exception.ReckonerException as err:
+        click.echo(click.style("{}".format(err), fg="red"))
+        ctx.exit(1)
+    click.echo(click.style("No schema validation errors found.", fg="green"))
 
 @cli.command()
 def version():

--- a/reckoner/schema_validator/course.py
+++ b/reckoner/schema_validator/course.py
@@ -61,3 +61,15 @@ def validate_course_file(course_file: BufferedReader):
             "Course file has schema validation errors. "
             "Please see the docs on schema validation or --log-level debug for in depth validation output.\n\n{}.".format('\n'.join(v.errors))
         )
+
+def lint_course_file(course_file: BufferedReader):
+    v = Validator()
+    course_file_object = Handler.load(course_file)
+    v.check(course_file_object)
+    if len(v.errors) > 0:
+        logging.error("Schema Validation Errors:")
+        for err in v.raw_errors:
+            logging.error("{}".format(err))
+        raise SchemaValidationError(
+            "Course file has schema validation errors."
+        )


### PR DESCRIPTION
Examples:
```
▶ reckoner lint course.yml
No schema validation errors found.
```

```
▶ reckoner lint course.yml
2020-10-22 18:32:20  root[95557]    ERROR  while constructing a mapping
  in "course.yml", line 2, column 1
found duplicate key "namespace" with value "foo" (original value: "demo")
  in "course.yml", line 4, column 1

Duplicate key found while loading your course YAML, please remove the duplicate key shown above.
```

Fixes #232