### PR TITLE
Add Better Error Messaging for Git Repositories

### DIFF
--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -293,7 +293,6 @@ class Chart(object):
         except Exception as err:
             logging.debug("Saving encountered error to chart result. See Below:")
             logging.debug("{}".format(err))
-            logging.debug(traceback.format_exc())
             self.result.failed = True
             self.result.error_reason = err
             raise err


### PR DESCRIPTION
This PR updates the error passing for failures in git commands when pulling repostories.
It raises errors, refines the errors raised and removes unnecessary repetition in traceback and in logging
It also fixes a bug where the missing branch logic was never triggered because of an extra '.' messing up the string match

Fixes #176