### PR TITLE
Fix course schema `plugin` field

### DIFF
--- a/reckoner/assets/course.schema.json
+++ b/reckoner/assets/course.schema.json
@@ -98,7 +98,7 @@
                     "hooks": {
                         "$ref": "#definitions/hooks"
                     },
-                    "plugins": {
+                    "plugin": {
                         "type": "string"
                     },
                     "files": {


### PR DESCRIPTION
In [./reckoner/chart.py:95](https://github.com/FairwindsOps/reckoner/blob/7e61ab04ea7eea5b82fc15283db0378e0fad1c74/reckoner/chart.py#L95) the course field `plugin` is extracted:

```python
self._plugin = self._chart.get('plugin')
```

But the [schema](https://github.com/FairwindsOps/reckoner/blob/7e61ab04ea7eea5b82fc15283db0378e0fad1c74/reckoner/assets/course.schema.json#L101) does not allow this, but only `plugins`, which is not used at all:

```json
"plugins": {
  "type": "string"
},
```

This results in the plugin functionality (e.g. with the helm plugin `secrets`) not working at all:

```yaml
# my-chart.yaml
context: minikube
namespace: default
repositories:
  regcred-secrets:
    git: git@gitlab.com:Instaffo/infrastructure/kubernetes/helm-charts/regcred-secrets.git
charts:
  my-chart:
    version: 0.1.0
    repository: regcred-secrets
    namespace: default
    plugin: secrets
```

```
reckoner update --log-level=debug -o my-chart my-course.yaml
[...]
2021-01-20 08:42:52 maiko root[74941] DEBUG Schema Validation Errors:
2021-01-20 08:42:52 maiko root[74941] DEBUG Additional properties are not allowed ('plugin' was unexpected)
Failed validating 'additionalProperties' in schema['properties']['charts']['additionalProperties']:
    {'additionalProperties': False,
     'properties': {'chart': {'type': 'string'},
                    'files': {'items': {'type': 'string'}, 'type': 'array'},
                    'hooks': {'$ref': '#definitions/hooks'},
                    'namespace': {'type': 'string'},
                    'namespace_management': {'additionalProperties': False,
                                             'properties': {'metadata': {'additionalProperties': False,
                                                                         'properties': {'annotations': {'type': 'object'},
                                                                                        'labels': {'type': 'object'}},
                                                                         'type': 'object'},
                                                            'settings': {'type': 'object'}},
                                             'type': 'object'},
                    'plugins': {'type': 'string'},
                    'repository': {'oneOf': [{'type': 'string'},
                                             {'$ref': '#definitions/repository'}],
                                   'x-custom-error-message': 'Problem '
                                                             'Parsing '
                                                             'Repositories '
                                                             'Schema; '
                                                             'expecting '
                                                             'string or '
                                                             'map'},
                    'set-values': {'type': 'object'},
                    'values': {'type': 'object'},
                    'values-strings': {'type': 'object'},
                    'version': {'type': 'string'}},
     'type': 'object',
     'x-custom-error-message': 'Problem Parsing Chart Schema'}

On instance['charts']['my-chart']:
    {'namespace': 'default',
     'plugin': 'secrets',
     'repository': 'regcred-secrets',
     'version': '0.1.0'}
⛵🔥 Encountered errors while reading course file ⛵🔥
(Err: Problem Parsing Chart Schema) Additional properties are not allowed ('plugin' was unexpected).
[...]
```

When using the field `plugins` (with an `s`) in the chart, it does not use the plugin:

```
[...]
2021-01-20 08:43:54 maiko root[75928] DEBUG helm upgrade --install my-chart /home/maiko/.cache/helm/repository/git@gitlab_com:Instaffo_infrastructure_kubernetes_helm-charts_regcred-secrets_git/ --namespace default --kube-context minikube --version 0.1.0
[...]
```