### PR TITLE
Fix 273 - fail when context does not exist

### DIFF
--- a/end_to_end_testing/course_files/24_test_no_context.yml
+++ b/end_to_end_testing/course_files/24_test_no_context.yml
@@ -1,4 +1,5 @@
-namespace: 21-test-diff
+namespace: 24-test-no-context
+context: thiscontextdoesnotexist
 repositories:
   ingress-nginx:
     url: https://kubernetes.github.io/ingress-nginx
@@ -6,10 +7,6 @@ minimum_versions: #set minimum version requirements here
   helm: 0.0.0
   reckoner: 0.0.0
 charts:
-  chart-with-namespace:
-    namespace: 21-test-diff
-    repository: ingress-nginx
-    chart: ingress-nginx
-  chart-without-namespace:
+  chart-with-no-context:
     repository: ingress-nginx
     chart: ingress-nginx

--- a/end_to_end_testing/tests/24_no_context.yaml
+++ b/end_to_end_testing/tests/24_no_context.yaml
@@ -1,0 +1,29 @@
+version: "2"
+name: No Context
+vars:
+  course: ../course_files/24_test_no_context
+testcases:
+- name: 24 - get-manifests
+  steps:
+  - script: |
+      reckoner get-manifests -a {{.course}} -o chart-with-no-context
+    assertions:
+    - result.code ShouldEqual 1
+- name: 24 - plot
+  steps:
+  - script: |
+      reckoner plot -a {{.course}} -o chart-with-no-context
+    assertions:
+    - result.code ShouldEqual 1
+- name: 24 - diff
+  steps:
+  - script: |
+      reckoner diff -a {{.course}} -o chart-with-no-context
+    assertions:
+    - result.code ShouldEqual 1
+- name: 24 - template
+  steps:
+  - script: |
+      reckoner template -a {{.course}} -o chart-with-no-context
+    assertions:
+    - result.code ShouldEqual 0

--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -371,7 +371,6 @@ class Chart(object):
             # Perform the template with the arguments
             return self.helm.get_manifest(self.args, plugin=self.plugin)
         except Exception as e:
-            logging.debug(traceback.format_exc())
             raise e
         finally:
             self.clean_up_temp_files()
@@ -382,7 +381,9 @@ class Chart(object):
         except HelmClientException as e:
             if "not found" in str(e):
                 logging.warn(f"Release {self.release_name} does not exist. Output will be the equal to 'template'")
-            manifest_response = ""
+                manifest_response = ""
+            else:
+                raise e
 
         template_response = self.__template_response(default_namespace, default_namespace_management, context).stdout
         diff = manifestDiff(manifest_response, template_response)
@@ -453,7 +454,6 @@ class Chart(object):
         # Build the file arguments from the `values: {}` in course.yml
         self.build_temp_values_files()
 
-
     def build_temp_values_files(self):
         """
         This method builds temporary files based on the values: settings
@@ -513,7 +513,6 @@ class Chart(object):
                                     "If you need $(THING) use $$(THING) to escape the `$`")
         except Exception as e:
             raise e
-
 
     def clean_up_temp_files(self):
         # Clean up all temp files used in the helm run

--- a/reckoner/cli.py
+++ b/reckoner/cli.py
@@ -157,7 +157,7 @@ def template(ctx, only, run_all, log_level, course_file=None, helm_args=None, dr
         r = Reckoner(course_file=course_file, helm_args=helm_args)
         # Convert tuple to list
         only = list(only)
-        logging.debug(f'Only tempalating the following charts: {only}')
+        logging.debug(f'Only templating the following charts: {only}')
         template_results = r.template(only)
         for result in template_results:
             if result.response is not None:
@@ -208,7 +208,7 @@ def get_manifests(ctx, only, run_all, log_level, course_file=None, helm_args=Non
         r = Reckoner(course_file=course_file, helm_args=helm_args)
         # Convert tuple to list
         only = list(only)
-        logging.debug(f'Only tempalating the following charts: {only}')
+        logging.debug(f'Only getting manifests for the following charts: {only}')
         manifests_results = r.get_manifests(only)
         for result in manifests_results:
             print(result.response.stdout)

--- a/reckoner/course.py
+++ b/reckoner/course.py
@@ -188,11 +188,7 @@ class Course(object):
                 logging.error(f'ERROR: {command} Failed on {chart.release_name}')
                 if not self.config.continue_on_error:
                     logging.error(f"Stopping '{command}' for chart due to an error! Some of your requested actions may not have been completed!")
-                    try:
-                        # Try to spit out the actuall useful error but not all responses are int he same format
-                        logging.error(str(e).splitlines()[2].replace('STDERR: ', ''))
-                    except Exception:
-                        logging.error(str(e))
+                    logging.error(str(e))
                     break
             finally:
                 # Always grab any results in the chart results

--- a/reckoner/helm/client.py
+++ b/reckoner/helm/client.py
@@ -115,7 +115,6 @@ class HelmClient(ABC):
         else:
             err = HelmClientException('Command Failed with output below:\nSTDOUT: {}\nSTDERR: {}\nCOMMAND: {}'.format(
                 response.stdout, response.stderr, response.command))
-            logging.debug(err)
             raise err
 
     @property


### PR DESCRIPTION
This PR imporves error handling and out put for the `get-manifests` command and, but extenation, the diff and upgrade commmand as well.Also, a couple typos, and formatting.

Fixes #273