### PR TITLE
Fix 170 - Add new version number to the output

### DIFF
--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -272,7 +272,13 @@ class Chart(object):
             finally:
                 self.clean_up_temp_files()
             # Log the stdout response in info
-            logging.info(self.result.response.stdout)
+
+
+            # Add new chart version to the response
+            log_output = self.result.response.stdout
+            if self.version:
+                log_output = log_output.replace('has been upgraded', f'has been upgraded to {self.version}')
+            logging.info(log_output)
 
             # Fire the post_install_hook
             self.post_install_hook.run()


### PR DESCRIPTION
Now, when  plot is called the new chart version number will be displayed in the first like of the outuput (if specified in the course)

Fixes #170

```
2021-01-24 17:00:36 C02DG0SRMD6R root[41571] INFO Release "redis-one" has been upgraded to 12.6.3. Happy Helming!
NAME: redis-one
LAST DEPLOYED: Sun Jan 24 17:00:35 2021
NAMESPACE: foo
STATUS: deployed
```