### PR TITLE
namespace management should utilize kube context

### DIFF
--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -163,12 +163,12 @@ class Chart(object):
 
     @property
     def namespace_management(self):
-        """ Namespace to install the course chart """
+        """ Parameters for augmenting namespaces we install charts into """
         return self._namespace_management
 
     @property
     def context(self):
-        """ Namespace to install the course chart """
+        """ Context to use to install the course chart """
         return self._context
 
     @property
@@ -227,7 +227,7 @@ class Chart(object):
         in the self.config option to avoid going back to the api for each chart.
         """
         if self.config.create_namespace and not self.dryrun:
-            nsm = NamespaceManager(self.namespace, self.namespace_management)
+            nsm = NamespaceManager(self.namespace, self.namespace_management, self.context)
             nsm.create_and_manage()
 
     def __pre_command(self, default_namespace=None, default_namespace_management={}, context=None) -> None:

--- a/reckoner/course.py
+++ b/reckoner/course.py
@@ -419,7 +419,6 @@ class Course(object):
 
         logging.debug("Reckoner Minimum Version is {}".format(reckoner_minimum_version))
         logging.debug("Reckoner Installed Version is {}".format(reckoner_version))
-
         r1 = semver.compare(reckoner_version, reckoner_minimum_version)
         if r1 < 0:
             raise MinimumVersionException("reckoner Minimum Version {} not met.".format(reckoner_minimum_version))

--- a/reckoner/kube.py
+++ b/reckoner/kube.py
@@ -22,7 +22,7 @@ from kubernetes import client, config
 
 class NamespaceManager(object):
 
-    def __init__(self, namespace_name, namespace_management) -> None:
+    def __init__(self, namespace_name, namespace_management, kube_context) -> None:
         """ Manages a namespace for the chart
         Accepts:
         - namespace: Which may be a string or a dictionary
@@ -36,6 +36,7 @@ class NamespaceManager(object):
             'overwrite',
             False
         )
+        self._kube_context = kube_context
         self.__load_config()
         self.config = Config()
 
@@ -46,7 +47,7 @@ class NamespaceManager(object):
 
     @property
     def namespace(self) -> str:
-        """ Namespace object we are managing 
+        """ Namespace object we are managing
         https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1Namespace.md"""
         return self._namespace
 
@@ -62,10 +63,16 @@ class NamespaceManager(object):
         from the chart and course """
         return self._overwrite
 
+    @property
+    def kube_context(self) -> str:
+        """ The kubernetes context that should be used
+        to create and manage the namespace """
+        return self._kube_context
+
     def __load_config(self):
         """ Protected method to load kubernetes config"""
         try:
-            config.load_kube_config()
+            config.load_kube_config(context=self.kube_context)
             self.v1client = client.CoreV1Api()
         except Exception as e:
             logging.error('Unable to load kubernetes configuration')

--- a/reckoner/tests/namespace_manager_mock.py
+++ b/reckoner/tests/namespace_manager_mock.py
@@ -4,7 +4,7 @@ from kubernetes import client, config
 
 class NamespaceManagerMock(object):
 
-    def __init__(self, namespace_name='', namespace_management={}) -> None:
+    def __init__(self, namespace_name='', namespace_management={}, kube_context=None) -> None:
         """ Manages a namespace for the chart
         Accepts:
         - namespace: Which may be a string or a dictionary
@@ -18,6 +18,7 @@ class NamespaceManagerMock(object):
             'overwrite',
             False
         )
+        self._kube_context = kube_context
         self.__load_config()
 
     @property
@@ -27,7 +28,7 @@ class NamespaceManagerMock(object):
 
     @property
     def namespace(self) -> str:
-        """ Namespace object we are managing 
+        """ Namespace object we are managing
         https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1Namespace.md"""
         return self._namespace
 
@@ -42,6 +43,12 @@ class NamespaceManagerMock(object):
         """ List of metadata settings parsed from the
         from the chart and course """
         return self._overwrite
+
+    @property
+    def kube_context(self) -> str:
+        """ The kubernetes context that should be used
+        to create and manage the namespace """
+        return self._kube_context
 
     def __load_config(self):
         """ Protected method do load kubernetes config"""

--- a/reckoner/tests/test_kube.py
+++ b/reckoner/tests/test_kube.py
@@ -44,7 +44,7 @@ class TestNamespaceManager(unittest.TestCase):
             "settings": {"overwrite": True}
         }
 
-        _ns_manager = NamespaceManager('test', settings)
+        _ns_manager = NamespaceManager('test', settings, None)
 
         self.assertTrue(_ns_manager.overwrite)
         self.assertEqual(_ns_manager.metadata, {
@@ -68,7 +68,7 @@ class TestNamespaceManager(unittest.TestCase):
             "settings": {"overwrite": False}
         }
 
-        _ns_manager = NamespaceManager('test', settings)
+        _ns_manager = NamespaceManager('test', settings, None)
 
         self.assertFalse(_ns_manager.overwrite)
         self.assertEqual(_ns_manager.metadata, {})
@@ -79,7 +79,7 @@ class TestNamespaceManager(unittest.TestCase):
             "metadata": {}
         }
 
-        _ns_manager = NamespaceManager('test', settings)
+        _ns_manager = NamespaceManager('test', settings, None)
 
         self.assertFalse(_ns_manager.overwrite)
         self.assertEqual(_ns_manager.metadata, {})


### PR DESCRIPTION
Fixes #468

This leverages the context portion of setting up the kubernetes client in the `NamespaceManager` object. Therefore, if we hit the kubernetes namespace management code it will properly set a context if it exists in the kube config, but will give a useful error if the context does not exist in the kube config:

```
2021-09-13 10:28:13 luke-macbook-fw.local root[98514] INFO Found Helm Version 3.3.4
2021-09-13 10:28:30 luke-macbook-fw.local root[98514] INFO Running 'install' on rbac-manager in rbac-manager
2021-09-13 10:28:30 luke-macbook-fw.local root[98514] ERROR Unable to load kubernetes configuration
2021-09-13 10:28:30 luke-macbook-fw.local root[98514] ERROR ERROR: install Failed on rbac-manager
2021-09-13 10:28:30 luke-macbook-fw.local root[98514] ERROR Invalid kube-config file. Expected object with name does-not-exist in /Users/luke/.kube/config/contexts list
⛵🔥 Encountered errors while reading course file ⛵🔥
Stopping 'install' for chart due to an error! Some of your requested actions may not have been completed!
```