### PR TITLE
[RD-34] Fix default namespace management

### DIFF
--- a/end_to_end_testing/run_go.sh
+++ b/end_to_end_testing/run_go.sh
@@ -14,7 +14,7 @@ go version
 cd /reckoner
 make build
 
-mv /reckoner/dist/reckoner_linux_amd64/reckoner /usr/local/bin/reckoner
+mv /reckoner/reckoner-go /usr/local/bin/reckoner
 reckoner version
 
 curl -LO https://github.com/ovh/venom/releases/download/v0.28.0/venom.linux-amd64

--- a/pkg/reckoner/namespace.go
+++ b/pkg/reckoner/namespace.go
@@ -77,12 +77,6 @@ func (c *Client) NamespaceManagement() error {
 	if err != nil {
 		return err
 	}
-	if c.CourseFile.DefaultNamespace != "" {
-		err := c.CreateOrPatchNamespace(c.CourseFile.NamespaceMgmt.Default.Settings.Overwrite, c.CourseFile.DefaultNamespace, c.CourseFile.NamespaceMgmt.Default, namespaces)
-		if err != nil {
-			return err
-		}
-	}
 	for _, release := range c.CourseFile.Releases {
 		err := c.CreateOrPatchNamespace(release.NamespaceMgmt.Settings.Overwrite, release.Namespace, release.NamespaceMgmt, namespaces)
 		if err != nil {


### PR DESCRIPTION
Because we already populate the default namespace for a given release during the course file parse there's no need to try and create it here. It will be created in the forloop below the removed code.

This should fix some of the e2e tests because it was attempting to create the default namespace twice before.