### PR TITLE
[RD-35] Add update command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,6 +66,7 @@ func init() {
 	rootCmd.AddCommand(diffCmd)
 	rootCmd.AddCommand(lintCmd)
 	rootCmd.AddCommand(getManifestsCmd)
+	rootCmd.AddCommand(updateCmd)
 
 	klog.InitFlags(nil)
 	pflag.CommandLine.AddGoFlag(flag.CommandLine.Lookup("v"))
@@ -95,11 +96,10 @@ var plotCmd = &cobra.Command{
 		if err != nil {
 			klog.Fatal(err)
 		}
-		output, err := client.Plot()
+		err = client.Plot()
 		if err != nil {
 			klog.Fatal(err)
 		}
-		fmt.Println(output)
 	},
 }
 
@@ -180,7 +180,7 @@ var lintCmd = &cobra.Command{
 
 var convertCmd = &cobra.Command{
 	Use:   "convert",
-	Short: "convert <course file> from v1 to v2 schema",
+	Short: "convert <course file>",
 	Long:  "Converts a course file from the v1 python schema to v2 go schema",
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		runAll = true
@@ -210,6 +210,23 @@ var convertCmd = &cobra.Command{
 		e.SetIndent(2)
 
 		err = e.Encode(newCourse)
+		if err != nil {
+			klog.Fatal(err)
+		}
+	},
+}
+
+var updateCmd = &cobra.Command{
+	Use:     "update",
+	Short:   "update <course file>",
+	Long:    "Only install/upgrade a release if there are changes.",
+	PreRunE: validateArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := reckoner.NewClient(courseFile, version, runAll, onlyRun, true, dryRun, createNamespaces, courseSchema)
+		if err != nil {
+			klog.Fatal(err)
+		}
+		err = client.Update()
 		if err != nil {
 			klog.Fatal(err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -224,11 +224,13 @@ var updateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := reckoner.NewClient(courseFile, version, runAll, onlyRun, true, dryRun, createNamespaces, courseSchema)
 		if err != nil {
-			klog.Fatal(err)
+			color.Red(err.Error())
+			os.Exit(1)
 		}
 		err = client.Update()
 		if err != nil {
-			klog.Fatal(err)
+			color.Red(err.Error())
+			os.Exit(1)
 		}
 	},
 }

--- a/end_to_end_testing/tests/01_basic.yaml
+++ b/end_to_end_testing/tests/01_basic.yaml
@@ -59,7 +59,7 @@ testcases:
       reckoner update {{.course}} -a
     assertions:
     - result.code ShouldEqual 0
-- name: 01 - update only release
+- name: 01 - template only release
   steps:
   - script: |
       reckoner template {{.course}} -o {{.release}}

--- a/pkg/reckoner/update.go
+++ b/pkg/reckoner/update.go
@@ -1,0 +1,42 @@
+// Copyright 2020 Fairwinds
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+package reckoner
+
+import (
+	"github.com/fairwindsops/reckoner/pkg/course"
+	"github.com/fatih/color"
+)
+
+func (c *Client) Update() error {
+	updatedReleases := []*course.Release{}
+	for i, r := range c.CourseFile.Releases {
+		thisReleaseDiff, err := c.diffRelease(r.Name, r.Namespace)
+		if err != nil {
+			return err
+		}
+		if thisReleaseDiff != "" {
+			color.Yellow("Update available for %s in namespace %s. Added to plot list.", r.Name, r.Namespace)
+			updatedReleases = append(updatedReleases, c.CourseFile.Releases[i])
+			continue
+		}
+		color.Green("No update necessary for %s in namespace %s.", r.Name, r.Namespace)
+	}
+	c.CourseFile.Releases = updatedReleases
+	err := c.Plot()
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
- move some diff functionality to a new function to only get individual diff string
- no need to return a string from the client.Plot() method because we never returned anything from it
- add update command to only run upgrades on releases that have diffs