### PR TITLE
[go] parse environment variables

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -187,7 +187,7 @@ var convertCmd = &cobra.Command{
 		return validateArgs(cmd, args)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		newCourse, err := course.ConvertV1toV2(courseFile)
+		newCourse, err := course.OpenCourseV2(courseFile, courseSchema)
 		if err != nil {
 			klog.Fatal(err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -94,11 +94,13 @@ var plotCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := reckoner.NewClient(courseFile, version, runAll, onlyRun, true, dryRun, createNamespaces, courseSchema)
 		if err != nil {
-			klog.Fatal(err)
+			color.Red(err.Error())
+			os.Exit(1)
 		}
 		err = client.Plot()
 		if err != nil {
-			klog.Fatal(err)
+			color.Red(err.Error())
+			os.Exit(1)
 		}
 	},
 }
@@ -111,11 +113,13 @@ var templateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := reckoner.NewClient(courseFile, version, runAll, onlyRun, false, true, false, courseSchema)
 		if err != nil {
-			klog.Fatal(err)
+			color.Red(err.Error())
+			os.Exit(1)
 		}
 		tmpl, err := client.TemplateAll()
 		if err != nil {
-			klog.Fatal(err)
+			color.Red(err.Error())
+			os.Exit(1)
 		}
 		fmt.Println(tmpl)
 	},
@@ -149,14 +153,17 @@ var diffCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := reckoner.NewClient(courseFile, version, runAll, onlyRun, false, true, false, courseSchema)
 		if err != nil {
-			klog.Fatal(err)
+			color.Red(err.Error())
+			os.Exit(1)
 		}
 		if err := client.UpdateHelmRepos(); err != nil {
-			klog.Fatal(err)
+			color.Red(err.Error())
+			os.Exit(1)
 		}
 		err = client.Diff()
 		if err != nil {
-			klog.Fatal(err)
+			color.Red(err.Error())
+			os.Exit(1)
 		}
 	},
 }
@@ -172,7 +179,8 @@ var lintCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		_, err := reckoner.NewClient(courseFile, version, runAll, onlyRun, false, true, false, courseSchema)
 		if err != nil {
-			klog.Fatal(err)
+			color.Red(err.Error())
+			os.Exit(1)
 		}
 		klog.Infof("course file %s is good to go!", courseFile)
 	},
@@ -189,18 +197,21 @@ var convertCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		newCourse, err := course.OpenCourseV2(courseFile, courseSchema)
 		if err != nil {
-			klog.Fatal(err)
+			color.Red(err.Error())
+			os.Exit(1)
 		}
 		w := os.Stdout
 		if inPlaceConvert {
 			f, err := os.OpenFile(courseFile, os.O_RDWR, 0644)
 			if err != nil {
-				klog.Fatal(err)
+				color.Red(err.Error())
+				os.Exit(1)
 			}
 			defer f.Close()
 			err = f.Truncate(0)
 			if err != nil {
-				klog.Fatalf("failed to truncate course file \"%s\": %s", courseFile, err)
+				color.Red("failed to truncate course file \"%s\": %s", courseFile, err)
+				os.Exit(1)
 			}
 			w = f
 		}
@@ -211,7 +222,8 @@ var convertCmd = &cobra.Command{
 
 		err = e.Encode(newCourse)
 		if err != nil {
-			klog.Fatal(err)
+			color.Red(err.Error())
+			os.Exit(1)
 		}
 	},
 }

--- a/pkg/course/course_test.go
+++ b/pkg/course/course_test.go
@@ -90,7 +90,7 @@ func TestConvertV1toV2(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ConvertV1toV2(tt.fileName)
+			got, err := convertV1toV2(tt.fileName)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/reckoner/plot.go
+++ b/pkg/reckoner/plot.go
@@ -64,8 +64,7 @@ func (c Client) Plot() error {
 		if !c.DryRun {
 			out, stdErr, err := c.Helm.Exec(args...)
 			if err != nil {
-				klog.Error(stdErr)
-				continue
+				return fmt.Errorf("error plotting release %s: %s", release.Name, stdErr)
 			}
 			fmt.Println(out)
 		} else {


### PR DESCRIPTION
Also changed in this PR:

* make conversion from v1 to v2 schema a private function since everything should happen with the OpenV2 function.
* changed all klog.Fatal() calls in the cmd package to red error output with exit code of 1 instead
* `reckoner convert` command no longer calls the ConvertV1toV2 function and instead simply uses OpenV2 function.