### PR TITLE
[go] fix kubecontext checking

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -140,7 +140,7 @@ var getManifestsCmd = &cobra.Command{
 	Long:    "Gets the manifests currently in the cluster.",
 	PreRunE: validateArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := reckoner.NewClient(courseFile, version, runAll, onlyRun, false, true, false, courseSchema, false)
+		client, err := reckoner.NewClient(courseFile, version, runAll, onlyRun, true, true, false, courseSchema, false)
 		if err != nil {
 			color.Red(err.Error())
 			os.Exit(1)
@@ -160,7 +160,7 @@ var diffCmd = &cobra.Command{
 	Long:    "Diffs the currently defined release and the one in the cluster",
 	PreRunE: validateArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := reckoner.NewClient(courseFile, version, runAll, onlyRun, false, true, false, courseSchema, continueOnError)
+		client, err := reckoner.NewClient(courseFile, version, runAll, onlyRun, true, true, false, courseSchema, continueOnError)
 		if err != nil {
 			color.Red(err.Error())
 			os.Exit(1)

--- a/end_to_end_testing/tests/24_no_context.yaml
+++ b/end_to_end_testing/tests/24_no_context.yaml
@@ -2,6 +2,7 @@ version: "2"
 name: No Context
 vars:
   course: ../course_files/24_test_no_context.yml
+  namespace: 24-test-no-context
 testcases:
 - name: 24 - get-manifests
   steps:
@@ -27,7 +28,8 @@ testcases:
       reckoner template {{.course}} -o chart-with-no-context
     assertions:
     - result.code ShouldEqual 0
-  - name: 24 - cleanup
-    steps:
-      - script: |
-          kubectl delete ns {{.namespace}}
+- name: 24 - cleanup
+  steps:
+    - script: |
+        # We shouldn't need this, but if for some reason the tests above don't pass, the NS may get created. Mainly needed for local tests.
+        kubectl delete ns {{.namespace}} || true

--- a/pkg/reckoner/client.go
+++ b/pkg/reckoner/client.go
@@ -92,7 +92,7 @@ func NewClient(fileName, version string, plotAll bool, releases []string, kubeCl
 	}
 
 	if kubeClient {
-		client.KubeClient = getKubeClient()
+		client.KubeClient = getKubeClient(courseFile.Context)
 	}
 
 	return client, nil
@@ -106,9 +106,9 @@ func (c *Client) Continue() bool {
 	return false
 }
 
-func getKubeClient() *kubernetes.Clientset {
+func getKubeClient(context string) *kubernetes.Clientset {
 	once.Do(func() {
-		kubeConf, err := config.GetConfig()
+		kubeConf, err := config.GetConfigWithContext(context)
 		if err != nil {
 			fmt.Println("Error getting kubeconfig:", err)
 			os.Exit(1)


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Make use of the toplevel chart key `context` so we use the configured kubecontext. If it does not exist in the kubeconfig, we should bail out.

### What changes did you make?

### What alternative solution should we consider, if any?