### PR TITLE
udpate CI for cross-arch docker, release candidates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: Goreleaser Snapshot
-          command: goreleaser --snapshot --skip-sign
+          command: goreleaser --snapshot --skip-sign -p 1
       - store_artifacts:
           path: dist
           destination: snapshot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,8 +58,6 @@ jobs:
     working_directory: /go/src/github.com/fairwindsops/reckoner
     docker:
       - image: circleci/golang:1.17
-        environment:
-          GO111MODULE: "on"
     steps:
       - checkout
       - run: make test
@@ -86,8 +84,6 @@ jobs:
     shell: /bin/bash
     docker:
       - image: goreleaser/goreleaser:v1.5.0
-        environment:
-          GO111MODULE: "on"
     steps:
       - checkout
       - setup_remote_docker:
@@ -103,7 +99,7 @@ jobs:
           command: |
             docker login -u _json_key -p "$(echo $GCP_ARTIFACTREADWRITE_JSON_KEY | base64 -d)" us-docker.pkg.dev
       - run: echo 'export GORELEASER_CURRENT_TAG="${CIRCLE_TAG}"' >> $BASH_ENV
-      - run: goreleaser
+      - run: goreleaser -p 1
   publish_docs:
     docker:
       - image: cimg/node:15.5.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,25 @@ references:
         only: /.*/
       tags:
         ignore: /.*/
+  enable_experimental_features: &enable_experimental_docker_features
+    run:
+      name: enable experimental features
+      command: |
+        set -ex
+        apk --update add openssh
+        ssh remote-docker \<<EOF
+          sudo bash -c 'echo "{\"experimental\": true}" > /etc/docker/daemon.json'
+          sudo systemctl restart docker
+        EOF
+  install_vault_alpine: &install_vault_alpine
+    run:
+      name: install hashicorp vault
+      command: |
+        apk --update add curl yq
+        cd /tmp
+        curl -LO https://releases.hashicorp.com/vault/1.9.4/vault_1.9.4_linux_amd64.zip
+        unzip vault_1.9.4_linux_amd64.zip
+        mv vault /usr/bin/vault
 jobs:
   test:
     working_directory: /go/src/github.com/fairwindsops/reckoner
@@ -61,6 +80,30 @@ jobs:
           root: /go/src/github.com/fairwindsops/reckoner
           paths:
           - dist
+  release:
+    working_directory: /home/circleci/go/src/github.com/fairwindsops/reckoner
+    resource_class: large
+    shell: /bin/bash
+    docker:
+      - image: goreleaser/goreleaser:v1.5.0
+        environment:
+          GO111MODULE: "on"
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.6
+      - *enable_experimental_docker_features
+      - *install_vault_alpine
+      - rok8s/get_vault_env:
+          vault_path: repo/global/env
+      - rok8s/get_vault_env:
+          vault_path: repo/reckoner/env
+      - run:
+          name: docker login
+          command: |
+            docker login -u _json_key -p "$(echo $GCP_ARTIFACTREADWRITE_JSON_KEY | base64 -d)" us-docker.pkg.dev
+      - run: echo 'export GORELEASER_CURRENT_TAG="${CIRCLE_TAG}"' >> $BASH_ENV
+      - run: goreleaser
   publish_docs:
     docker:
       - image: cimg/node:15.5.1
@@ -131,19 +174,17 @@ workflows:
           name: "End-To-End Kubernetes 1.22.0"
           kind_node_image: "kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047"
           <<: *e2e_configuration
-  # release:
-  #   jobs:
-  #     - publish_docs:
-  #         filters:
-  #           branches:
-  #             ignore: /.*/
-  #           tags:
-  #             only: /.*/
-  #     - rok8s/github_release:
-  #         requires:
-  #           - release
-  #         filters:
-  #           branches:
-  #             ignore: /.*/
-  #           tags:
-  #             only: /.*/
+  release:
+    jobs:
+      - publish_docs:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      - release:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,9 +10,12 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     goarm:
       - 6
       - 7
+checksum:
+  name_template: "checksums.txt"
 release:
   prerelease: auto
   footer: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,7 +43,7 @@ dockers:
   - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:v{{ .Major }}-amd64"
   - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:v{{ .Major }}.{{ .Minor }}-amd64"
   use: buildx
-  dockerfile: Dockerfile-go
+  dockerfile: Dockerfile
   build_flag_templates:
   - "--platform=linux/amd64"
 - image_templates:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,11 +13,6 @@ builds:
     goarm:
       - 6
       - 7
-dockers:
-- image_templates:
-  - "quay.io/fairwinds/reckoner:go-{{ .Tag }}"
-  - "quay.io/fairwinds/reckoner:go-v{{ .Major }}"
-  - "quay.io/fairwinds/reckoner:go-v{{ .Major }}.{{ .Minor }}"
 release:
   prerelease: auto
   footer: |
@@ -28,7 +23,7 @@ release:
     ```
 
     ```
-    cosign verify us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v5 --key https://artifacts.fairwinds.com/cosign.pub
+    cosign verify us-docker.pkg.dev/fairwinds-ops/oss/reckoner:v5 --key https://artifacts.fairwinds.com/cosign.pub
     ```
 signs:
 - cmd: cosign
@@ -42,16 +37,16 @@ docker_signs:
 dockers:
 - image_templates:
   - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:{{ .Tag }}-amd64"
-  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}-amd64"
-  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}.{{ .Minor }}-amd64"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:v{{ .Major }}-amd64"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:v{{ .Major }}.{{ .Minor }}-amd64"
   use: buildx
   dockerfile: Dockerfile-go
   build_flag_templates:
   - "--platform=linux/amd64"
 - image_templates:
   - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:{{ .Tag }}-arm64v8"
-  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}-arm64v8"
-  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}.{{ .Minor }}-arm64v8"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:v{{ .Major }}-arm64v8"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:v{{ .Major }}.{{ .Minor }}-arm64v8"
   use: buildx
   goarch: arm64
   dockerfile: Dockerfile
@@ -59,8 +54,8 @@ dockers:
   - "--platform=linux/arm64/v8"
 - image_templates:
   - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:{{ .Tag }}-armv7"
-  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}-armv7"
-  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}.{{ .Minor }}-armv7"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:v{{ .Major }}-armv7"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:v{{ .Major }}.{{ .Minor }}-armv7"
   use: buildx
   goarch: arm64
   dockerfile: Dockerfile
@@ -72,13 +67,13 @@ docker_manifests:
   - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:{{ .Tag }}-amd64"
   - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:{{ .Tag }}-arm64v8"
   - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:{{ .Tag }}-armv7"
-- name_template: us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}
+- name_template: us-docker.pkg.dev/fairwinds-ops/oss/reckoner:v{{ .Major }}
   image_templates:
-  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}-amd64"
-  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}-arm64v8"
-  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}-armv7"
-- name_template: us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}.{{ .Minor }}
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:v{{ .Major }}-amd64"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:v{{ .Major }}-arm64v8"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:v{{ .Major }}-armv7"
+- name_template: us-docker.pkg.dev/fairwinds-ops/oss/reckoner:v{{ .Major }}.{{ .Minor }}
   image_templates:
-  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}.{{ .Minor }}-amd64"
-  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}.{{ .Minor }}-arm64v8"
-  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}.{{ .Minor }}-armv7"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:v{{ .Major }}.{{ .Minor }}-amd64"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:v{{ .Major }}.{{ .Minor }}-arm64v8"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:v{{ .Major }}.{{ .Minor }}-armv7"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,4 +18,67 @@ dockers:
   - "quay.io/fairwinds/reckoner:go-{{ .Tag }}"
   - "quay.io/fairwinds/reckoner:go-v{{ .Major }}"
   - "quay.io/fairwinds/reckoner:go-v{{ .Major }}.{{ .Minor }}"
+release:
+  prerelease: auto
+  footer: |
+    You can verify the signatures of both the checksums.txt file and the published docker images using [cosign](https://github.com/sigstore/cosign).
+
+    ```
+    cosign verify-blob checksums.txt --signature=checksums.txt.sig  --key https://artifacts.fairwinds.com/cosign.pub
+    ```
+
+    ```
+    cosign verify us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v5 --key https://artifacts.fairwinds.com/cosign.pub
+    ```
+signs:
+- cmd: cosign
+  args: ["sign-blob", "--key=hashivault://cosign", "-output-signature=${signature}", "${artifact}"]
+  artifacts: checksum
+
+docker_signs:
+- artifacts: all
+  args: ["sign", "--key=hashivault://cosign", "${artifact}", "-r"]
+
+dockers:
+- image_templates:
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:{{ .Tag }}-amd64"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}-amd64"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}.{{ .Minor }}-amd64"
+  use: buildx
   dockerfile: Dockerfile-go
+  build_flag_templates:
+  - "--platform=linux/amd64"
+- image_templates:
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:{{ .Tag }}-arm64v8"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}-arm64v8"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}.{{ .Minor }}-arm64v8"
+  use: buildx
+  goarch: arm64
+  dockerfile: Dockerfile
+  build_flag_templates:
+  - "--platform=linux/arm64/v8"
+- image_templates:
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:{{ .Tag }}-armv7"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}-armv7"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}.{{ .Minor }}-armv7"
+  use: buildx
+  goarch: arm64
+  dockerfile: Dockerfile
+  build_flag_templates:
+  - "--platform=linux/arm/v7"
+docker_manifests:
+- name_template: us-docker.pkg.dev/fairwinds-ops/oss/reckoner:{{ .Tag }}
+  image_templates:
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:{{ .Tag }}-amd64"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:{{ .Tag }}-arm64v8"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:{{ .Tag }}-armv7"
+- name_template: us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}
+  image_templates:
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}-amd64"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}-arm64v8"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}-armv7"
+- name_template: us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}.{{ .Minor }}
+  image_templates:
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}.{{ .Minor }}-amd64"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}.{{ .Minor }}-arm64v8"
+  - "us-docker.pkg.dev/fairwinds-ops/oss/reckoner:go-v{{ .Major }}.{{ .Minor }}-armv7"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ release:
     ```
 
     ```
-    cosign verify us-docker.pkg.dev/fairwinds-ops/oss/reckoner:v5 --key https://artifacts.fairwinds.com/cosign.pub
+    cosign verify us-docker.pkg.dev/fairwinds-ops/oss/reckoner:v6 --key https://artifacts.fairwinds.com/cosign.pub
     ```
 signs:
 - cmd: cosign

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM python:3.8
+FROM scratch
 
-ADD . /bin/reckoner
-RUN pip install ./reckoner
-
-ENTRYPOINT ["reckoner"]
-CMD ["--help"]
+USER nobody
+COPY reckoner /
+WORKDIR /
+ENTRYPOINT ["/reckoner"]

--- a/Dockerfile-go
+++ b/Dockerfile-go
@@ -1,6 +1,0 @@
-FROM scratch
-
-USER nobody
-COPY reckoner /
-WORKDIR /
-ENTRYPOINT ["/reckoner"]


### PR DESCRIPTION
This PR fixes #531

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Update CI to our standards.

### What changes did you make?
- Replace original Dockerfile with the Dockerfile-go and remove Dockerfile-go
- Update .goreleaser.yml to include prereleases, cross-arch builds, and signing
- Update circleci to account for all of this.
- Push images to gcr instead of quay
- remove the `go-` from the docker tags in gcr

NOTE:

I used a different regex for the release steps. I think we shouldn't be publishing docs on release candidates, so I filtered them out. We run goreleaser on all valid `vx.x.x` tags.

### What alternative solution should we consider, if any?
n/a