### PR TITLE
Fix to the env var escaping

### DIFF
--- a/pkg/course/course.go
+++ b/pkg/course/course.go
@@ -628,7 +628,7 @@ func parseSecrets(courseData []byte) error {
 func parseEnv(data string) (string, error) {
 	dataWithEnv := os.Expand(data, func(key string) string {
 		if key == "$" {
-			return "$$"
+			return "$"
 		}
 		if value, ok := os.LookupEnv(key); ok {
 			return value

--- a/pkg/course/course_test.go
+++ b/pkg/course/course_test.go
@@ -249,7 +249,7 @@ func Test_parseEnv(t *testing.T) {
 		{
 			name: "escaping test",
 			data: "$$TEST_ENV_KEY",
-			want: "$$TEST_ENV_KEY",
+			want: "$TEST_ENV_KEY",
 			envMap: map[string]string{
 				"TEST_ENV_KEY": "test-env-value",
 			},


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Previous logic put the `$$` back, rather than replacing it with a single `$`

### What changes did you make?
One character removed in the output of the check, and fixed the test.
### What alternative solution should we consider, if any?