### PR TITLE
Don't parse env on convert command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -276,6 +276,7 @@ var convertCmd = &cobra.Command{
 		return validateCobraArgs(cmd, args)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		course.ParseEnv = false
 		newCourse, err := course.OpenCourseFile(courseFile, courseSchema)
 		if err != nil {
 			color.Red(err.Error())

--- a/pkg/course/course.go
+++ b/pkg/course/course.go
@@ -34,6 +34,7 @@ import (
 
 var (
 	SchemaValidationError error = errors.New("Course file has schema validation errors")
+	ParseEnv              bool  = true
 )
 
 // FileV2 is the heart of reckoner, it contains the definitions of the releases to be installed
@@ -641,6 +642,9 @@ func parseSecrets(courseData []byte) error {
 }
 
 func parseEnv(data string) (string, error) {
+	if !ParseEnv {
+		return data, nil
+	}
 	dataWithEnv := os.Expand(data, func(key string) string {
 		if key == "$" {
 			return "$"


### PR DESCRIPTION
This PR fixes #577

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
When running `reckoner convert`, we shouldn't parse environment variables

### What changes did you make?
Added a package variable to disable env parsing

### What alternative solution should we consider, if any?
There's likely a cleaner way to do this, I'm not overly happy about using a global for this, but due to the extreme ways in which we have to have to handle yaml, this may be necessary