### PR TITLE
make shell test work universally (hopefully)

### DIFF
--- a/pkg/course/shellSecrets_test.go
+++ b/pkg/course/shellSecrets_test.go
@@ -15,6 +15,7 @@
 package course
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -117,8 +118,9 @@ func Test_newShellExecutor(t *testing.T) {
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
-				assert.EqualValues(t, tt.want, got)
+				assert.NoError(t, err)                                                   // check for errors generally
+				assert.Regexp(t, regexp.MustCompile("^.+bin/echo$"), got.Executable, "") // handle any *bin/echo, such as /usr/bin/echo
+				assert.EqualValues(t, tt.want.Args, got.Args)                            // also verify args
 			}
 		})
 	}


### PR DESCRIPTION
## Description
### What's the goal of this PR?

make the tests for shells work universally. they were failing on some Ubuntu-based distros at the least.

### What changes did you make?

The original test just made sure the result of `newShellExecutor()` matched an object hardcoded in `Test_newShellExecutor()`.
Now we independently test the attributes of the resulting object against what we want from the test, using a regex to test `got.Executable` and EqualValues for `got.Args`, respectively.

### What alternative solution should we consider, if any?

We talked about supporting a list of possible places to expect `echo` on a distribution, but what if the system configuration is valid and functional, but we didn't include support? Ultimately we decided to go with a regex so we likely won't have to look at this again for a long, long time.
