### PR TITLE
Fix the reference to an old goldilocks chart that referenced a removed bitnami chart

### DIFF
--- a/end_to_end_testing/course_files/10_test_git_chart.yaml
+++ b/end_to_end_testing/course_files/10_test_git_chart.yaml
@@ -18,7 +18,7 @@ charts:
       path: stable
   goldilocks-10:
     chart: goldilocks
-    version: 125e58c33b29fb28e419732997aff1325578ddfa
+    version: 62e94e8412a34c2ad7e6ddf0ecb27ba054748a2e
     repository:
       git: https://github.com/FairwindsOps/charts
       path: stable


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Tests started failing right after bitnami removed a bunch of old charts from their index. The end to end test for git charts referenced an older version of the goldilocks chart, which had a reference to a removed metrics-server chart version.

This PR will fix the test

### What changes did you make?
Updated the revision of the goldilocks chart to the latest HEAD on the charts repo

### What alternative solution should we consider, if any?
n/a