### PR TITLE
update copyright to 2022

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017, FairwindsOps Inc.
+   Copyright 2022, FairwindsOps Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Fairwinds
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
 package cmd
 
 import (

--- a/cmd/validation.go
+++ b/cmd/validation.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/validation_test.go
+++ b/cmd/validation_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/course/argocd.go
+++ b/pkg/course/argocd.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Fairwinds
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
 package course
 
 // We may use these imports to track ArgoCD Applications exactly. However,

--- a/pkg/course/course.go
+++ b/pkg/course/course.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/course/course_test.go
+++ b/pkg/course/course_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/course/namespace.go
+++ b/pkg/course/namespace.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Fairwinds
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
 package course
 
 import (

--- a/pkg/course/namespace_test.go
+++ b/pkg/course/namespace_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Fairwinds
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
 package course
 
 import (

--- a/pkg/course/shellSecrets.go
+++ b/pkg/course/shellSecrets.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/course/shellSecrets_test.go
+++ b/pkg/course/shellSecrets_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/reckoner/argocd.go
+++ b/pkg/reckoner/argocd.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Fairwinds
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
 package reckoner
 
 import (

--- a/pkg/reckoner/argocd_test.go
+++ b/pkg/reckoner/argocd_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Fairwinds
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
 package reckoner
 
 import (

--- a/pkg/reckoner/client.go
+++ b/pkg/reckoner/client.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/reckoner/diff.go
+++ b/pkg/reckoner/diff.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/reckoner/diff_test.go
+++ b/pkg/reckoner/diff_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/reckoner/git.go
+++ b/pkg/reckoner/git.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/reckoner/hook.go
+++ b/pkg/reckoner/hook.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/reckoner/import.go
+++ b/pkg/reckoner/import.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/reckoner/import_test.go
+++ b/pkg/reckoner/import_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/reckoner/manifest_test.go
+++ b/pkg/reckoner/manifest_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/reckoner/manifests.go
+++ b/pkg/reckoner/manifests.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/reckoner/namespace.go
+++ b/pkg/reckoner/namespace.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/reckoner/namespace_test.go
+++ b/pkg/reckoner/namespace_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/reckoner/plot.go
+++ b/pkg/reckoner/plot.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/reckoner/plot_test.go
+++ b/pkg/reckoner/plot_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/reckoner/split_test.go
+++ b/pkg/reckoner/split_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Fairwinds
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
 package reckoner
 
 import (

--- a/pkg/reckoner/update.go
+++ b/pkg/reckoner/update.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Fairwinds
+// Copyright 2022 Fairwinds
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

Keep copyright up to date

### What changes did you make?

```sh
sed -i 's|Copyright 2020 Fairwinds|Copyright 2022 Fairwinds|g' $(grep -r 'Copyright 2020 Fairwinds' . | cut -d':' -f1 | sort -u)
```

```sh
find . -type f -not -path "./.git*" -not -path "./.*" -iname "*.go" -exec grep -Hc 'Copyright 2022 Fairwinds' {} \; | grep -v 'go:1'
```

and manually added preamble on files that came back from the `find`


### What alternative solution should we consider, if any?

n/a