### PR TITLE
Add the ability to ignoreDifferences in an argoCD application manifest

### DIFF
--- a/pkg/course/argocd.go
+++ b/pkg/course/argocd.go
@@ -47,10 +47,11 @@ type ArgoApplicationSpecDestination struct {
 }
 
 type ArgoApplicationSpec struct {
-	Source      ArgoApplicationSpecSource      `yaml:"source"`
-	Destination ArgoApplicationSpecDestination `yaml:"destination"`
-	Project     string                         `yaml:"project"`
-	SyncPolicy  ArgoApplicationSpecSyncPolicy  `yaml:"syncPolicy,omitempty"`
+	Source            ArgoApplicationSpecSource       `yaml:"source"`
+	Destination       ArgoApplicationSpecDestination  `yaml:"destination"`
+	Project           string                          `yaml:"project"`
+	SyncPolicy        ArgoApplicationSpecSyncPolicy   `yaml:"syncPolicy,omitempty"`
+	IgnoreDifferences []ArgoResourceIgnoreDifferences `yaml:"ignoreDifferences,omitempty"`
 }
 
 // ArgoApplicationMetadata contains the k8s metadata for the gitops agent CustomResource.
@@ -67,4 +68,17 @@ type ArgoApplication struct {
 	APIVersion string                  `yaml:"apiVersion"`
 	Metadata   ArgoApplicationMetadata `yaml:"metadata"`
 	Spec       ArgoApplicationSpec     `yaml:"spec"`
+}
+
+// ResourceIgnoreDifferences contains resource filter and list of json paths which should be ignored during comparison with live state.
+type ArgoResourceIgnoreDifferences struct {
+	Group             string   `yaml:"group,omitempty"`
+	Kind              string   `yaml:"kind"`
+	Name              string   `yaml:"name,omitempty"`
+	Namespace         string   `yaml:"namespace,omitempty"`
+	JSONPointers      []string `yaml:"jsonPointers,omitempty"`
+	JQPathExpressions []string `yaml:"jqPathExpressions,omitempty"`
+	// ManagedFieldsManagers is a list of trusted managers. Fields mutated by those managers will take precedence over the
+	// desired state defined in the SCM and won't be displayed in diffs
+	ManagedFieldsManagers []string `yaml:"managedFieldsManagers,omitempty"`
 }

--- a/pkg/course/course.go
+++ b/pkg/course/course.go
@@ -16,7 +16,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -348,7 +347,7 @@ func OpenCourseFile(fileName string, schema []byte) (*FileV2, error) {
 // OpenCourseV2 opens a v2 schema course file
 func OpenCourseV2(fileName string) (*FileV2, error) {
 	courseFile := &FileV2{}
-	data, err := ioutil.ReadFile(fileName)
+	data, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, err
 	}
@@ -367,7 +366,7 @@ func OpenCourseV2(fileName string) (*FileV2, error) {
 // OpenCourseV1 opens a v1 schema course file
 func OpenCourseV1(fileName string) (*FileV1, error) {
 	courseFile := &FileV1{}
-	data, err := ioutil.ReadFile(fileName)
+	data, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reckoner/plot.go
+++ b/pkg/reckoner/plot.go
@@ -14,7 +14,6 @@ package reckoner
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -235,7 +234,7 @@ func filesArgs(files []string, baseDir string) []string {
 
 // makeTempValuesFile puts the values section into a temporary values file
 func makeTempValuesFile(values map[string]interface{}) (*os.File, error) {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "reckoner-")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "reckoner-")
 	if err != nil {
 		return nil, fmt.Errorf("cannot create temporary file: %s", err)
 	}


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
It's common with certain applications to ignoreDifferences for specific things. The use-case I have is to ignore it in the prometheus chart, which has a process to modify the webhook failurePolicy after creation, which confuses argoCD.

### What changes did you make?
Added the argocd structs for ignoreDifferences

Also fixed a linter error related to the ioutil package

### What alternative solution should we consider, if any?
n/a