### PR TITLE
surface any errors encountered during schema validation

### DIFF
--- a/pkg/course/course.go
+++ b/pkg/course/course.go
@@ -338,7 +338,7 @@ func OpenCourseFile(fileName string, schema []byte) (*FileV2, error) {
 
 	if err := courseFile.validateJsonSchema(schema); err != nil {
 		klog.V(3).Infof("failed to validate jsonSchema in course file: %s", fileName)
-		return nil, SchemaValidationError
+		return nil, err
 	}
 
 	return courseFile, nil
@@ -562,12 +562,12 @@ func (f *FileV2) validateJsonSchema(schemaData []byte) error {
 
 	jsonData, err := json.Marshal(f)
 	if err != nil {
-		return SchemaValidationError
+		return err
 	}
 
 	result, err := schema.Validate(gojsonschema.NewBytesLoader(jsonData))
 	if err != nil {
-		return SchemaValidationError
+		return err
 	}
 	if len(result.Errors()) > 0 {
 		for _, err := range result.Errors() {


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Currently, if the marshalling the file to JSON fails, reckoner returns a non-descriptive error.

```
failed to validate jsonSchema in course file: course.yml
Course file has schema validation errors - error opening course file course.yml: Course file has schema validation errors
```

This PR changes that error to:

```
Course file has schema validation errors - error opening course file course.yml: unable to parse secrets: yaml: line 3: mapping values are not allowed in this context
```
### What changes did you make?
Instead of passing the generic SchemaValidationError, we pass back the actual error. The SchemaValidationError is only used if there are actual schema validation errors.

### What alternative solution should we consider, if any?
n/a