### PR TITLE
chore: add apple silicon processors build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,7 @@ clean:
 # Cross compilation
 build-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(BINARY_NAME) -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -s -w" -v
+build-apple-silicon:
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GOBUILD) -o $(BINARY_NAME) -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -s -w" -v
 build-docker: build-linux
 	docker build -t quay.io/fairwinds/reckoner:go-dev -f Dockerfile .


### PR DESCRIPTION
Add build reckoner commands for Apple Silicon chips (macbooks M1 and M2)


This PR fixes #

## Checklist
* [ ] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

### What changes did you make?

### What alternative solution should we consider, if any?

