### PR TITLE
Bug: Fix for broken make due to lint error

### DIFF
--- a/pkg/course/course.go
+++ b/pkg/course/course.go
@@ -589,7 +589,7 @@ func parseSecrets(courseData []byte) error {
 		var backend *secrets.Backend
 		switch secret.Backend {
 		case "ShellExecutor":
-			if secret.Script == nil || len(secret.Script) == 0 {
+			if len(secret.Script) == 0 {
 				return fmt.Errorf("ShellExecutor secret %s has no script, or is not in an array format in the course file", secret.Name)
 			}
 			executor, err := newShellExecutor(secret.Script)


### PR DESCRIPTION
This PR fixes a lint error in `make build`

## Checklist
* [ ] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
`make build` fails due to a lint error. This fix resolves that issue

### What changes did you make?
A small lint fix (The null check was unneeded)

